### PR TITLE
XtraBackup source

### DIFF
--- a/doc/config/source/xtrabackup.xml
+++ b/doc/config/source/xtrabackup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<source type="xtrabackup">
+  <!-- optional, default=false -->
+  <option name="showStdErr" value="true" />
+
+  <!-- optional, default=localhost -->
+  <option name="host" value="myhost" />
+
+  <!-- optional, default=system user -->
+  <option name="user" value="myUserName" />
+
+  <!-- optional, default=none -->
+  <option name="password" value="mySecretPassword" />
+
+  <!-- optional, default=all -->
+  <option name="databases" value="myDB1,myDB2,myDB3.table1" />
+
+  <!-- optional, default=all -->
+  <option name="include" value="^mydatabase[.]mytable" />
+</source>

--- a/src/Backup/Source/XtraBackup.php
+++ b/src/Backup/Source/XtraBackup.php
@@ -1,0 +1,194 @@
+<?php
+namespace phpbu\App\Backup\Source;
+
+use phpbu\App\Backup\Cli\Binary;
+use phpbu\App\Backup\Cli\Cmd;
+use phpbu\App\Backup\Cli\Exec;
+use phpbu\App\Backup\Source;
+use phpbu\App\Backup\Target;
+use phpbu\App\Exception;
+use phpbu\App\Result;
+use phpbu\App\Util;
+
+/**
+ * XtraBackup (using the innobackupex script) source class.
+ *
+ * @package    phpbu
+ * @subpackage Backup
+ * @author     Francis Chuang <francis.chuang@gmail.com>
+ * @author     Sebastian Feldmann <sebastian@phpbu.de>
+ * @copyright  Sebastian Feldmann <sebastian@phpbu.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://phpbu.de/
+ * @since      Class available since Release 2.0.0
+ */
+class XtraBackup extends Binary implements Source
+{
+    /**
+     * Show stdErr
+     *
+     * @var boolean
+     */
+    private $showStdErr;
+
+    /**
+     * Host to connect to
+     * --host <hostname>
+     *
+     * @var string
+     */
+    private $host;
+
+    /**
+     * User to connect with
+     * --user <username>
+     *
+     * @var string
+     */
+    private $user;
+
+    /**
+     * Password to authenticate with
+     * --password <password>
+     *
+     * @var string
+     */
+    private $password;
+
+    /**
+     * Regular expression matching the tables to be backed up.
+     * The regex should match the full qualified name: mydatabase.mytable
+     * --tables string
+     *
+     * @var string
+     */
+    private $include;
+
+    /**
+     * List of databases and/or tables to backup
+     * Tables must e fully qualified: mydatabase.mytable
+     * --databases array of strings
+     *
+     * @var array
+     */
+    private $databases;
+
+    /**
+     * Setup.
+     *
+     * @see    \phpbu\App\Backup\Source
+     * @param  array $conf
+     * @throws \phpbu\App\Exception
+     */
+    public function setup(array $conf = array())
+    {
+        $this->setupXtraBackup($conf);
+        $this->setupSourceData($conf);
+
+        $this->host       = Util\Arr::getValue($conf, 'host');
+        $this->user       = Util\Arr::getValue($conf, 'user');
+        $this->password   = Util\Arr::getValue($conf, 'password');
+        $this->showStdErr = Util\Str::toBoolean(Util\Arr::getValue($conf, 'showStdErr', ''), false);
+    }
+
+    /**
+     * Search for innobackupex command.
+     *
+     * @param array $conf
+     */
+    protected function setupXtraBackup(array $conf)
+    {
+        if (empty($this->binary)) {
+            $this->binary = $this->detectCommand('innobackupex', Util\Arr::getValue($conf, 'pathToXtraBackup'));
+        }
+    }
+
+    /**
+     * Get tables and databases to backup.
+     *
+     * @param array $conf
+     */
+    protected function setupSourceData(array $conf)
+    {
+        $this->include       = Util\Arr::getValue($conf, 'include');
+        $this->databases     = Util\Str::toList(Util\Arr::getValue($conf, 'databases'));
+    }
+
+    /**
+     * (non-PHPDoc)
+     *
+     * @see    \phpbu\App\Backup\Source
+     * @param  \phpbu\App\Backup\Target $target
+     * @param  \phpbu\App\Result        $result
+     * @return \phpbu\App\Backup\Source\Status
+     * @throws \phpbu\App\Exception
+     */
+    public function backup(Target $target, Result $result)
+    {
+        $exec         = $this->getExec($target);
+        $innobackupex = $this->execute($exec);
+
+        $result->debug($innobackupex->getCmd());
+
+        if (!$innobackupex->wasSuccessful()) {
+            throw new Exception('XtraBackup failed');
+        }
+
+        return Status::create()->uncompressed()->dataPath($this->getDumpDir($target));
+    }
+
+    /**
+     * Create the Exec to run the innobackupex backup and apply-log commands.
+     *
+     * @param  \phpbu\App\Backup\Target $target
+     * @return \phpbu\App\Backup\Cli\Exec
+     * @throws Exception
+     */
+    public function getExec(Target $target)
+    {
+        if (null == $this->exec) {
+            $dump       = $this->getDumpDir($target);
+            $this->exec = new Exec();
+            $cmd        = new Cmd($this->binary);
+            $cmd2       = new Cmd($this->binary);
+            $this->exec->addCommand($cmd);
+            $this->exec->addCommand($cmd2);
+
+            // no std error unless it is activated
+            if (!$this->showStdErr) {
+                $cmd->silence();
+                $cmd2->silence();
+                // i kill you
+            }
+
+            $cmd->addOption('--no-timestamp');
+            $this->addOptionIfNotEmpty($cmd, '--user', $this->user);
+            $this->addOptionIfNotEmpty($cmd, '--password', $this->password);
+            $this->addOptionIfNotEmpty($cmd, '--host', $this->host);
+
+            if (!empty($this->include)) {
+                $cmd->addOption('--include', $this->include);
+            } else if (count($this->databases)) {
+                $cmd->addOption('--databases', implode(' ', $this->databases));
+            }
+
+            $cmd->addArgument($dump);
+
+            $cmd2->addOption('--apply-log');
+            $cmd2->addArgument($dump);
+        }
+
+        return $this->exec;
+    }
+
+    /**
+     * Get the XtraBackup dump directory.
+     *
+     * @param  \phpbu\App\Backup\Target $target
+     * @return string
+     */
+    public function getDumpDir(Target $target)
+    {
+        return $target->getPath() . '/dump';
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -38,6 +38,7 @@ abstract class Factory
             'tar'         => '\\phpbu\\App\\Backup\\Source\\Tar',
             'elasticdump' => '\\phpbu\\App\\Backup\\Source\\Elasticdump',
             'arangodump' => '\\phpbu\\App\\Backup\\Source\\Arangodump',
+            'xtrabackup' => '\\phpbu\\App\\Backup\\Source\\XtraBackup',
         ),
         'check'   => array(
             'sizemin'                 => '\\phpbu\\App\\Backup\\Check\\SizeMin',

--- a/tests/_files/bin/innobackupex
+++ b/tests/_files/bin/innobackupex
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+# unit test fake innobackupex command that is executable
+
+exit 0

--- a/tests/phpbu/Backup/Source/XtraBackupTest.php
+++ b/tests/phpbu/Backup/Source/XtraBackupTest.php
@@ -1,0 +1,280 @@
+<?php
+namespace phpbu\App\Backup\Source;
+
+/**
+ * XtraBackupTest
+ *
+ * @package    phpbu
+ * @subpackage tests
+ * @author     Francis Chuang <francis.chuang@gmail.com>
+ * @author     Sebastian Feldmann <sebastian@phpbu.de>
+ * @copyright  Sebastian Feldmann <sebastian@phpbu.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpbu.de/
+ * @since      Class available since Release 2.0.0
+ */
+class XtraBackupTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * XtraBackup
+     *
+     * @var \phpbu\App\Backup\Source\XtraBackup
+     */
+    protected $xtrabackup;
+
+    /**
+     * Setup XtraBackup
+     */
+    public function setUp()
+    {
+        $this->xtrabackup = new XtraBackup();
+        $this->xtrabackup->setBinary('innobackupex');
+    }
+
+    /**
+     * Clear XtraBackup
+     */
+    public function tearDown()
+    {
+        $this->xtrabackup = null;
+    }
+
+    /**
+     * Tests XtraBackup::getExec
+     */
+    public function testDefault()
+    {
+        $this->xtrabackup->setup(array());
+        /** @var \phpbu\App\Backup\Cli\Exec $exec */
+        $exec = $this->xtrabackup->getExec($this->getTargetMock());
+        $cmd  = (string) $exec->getExec();
+
+        $this->assertEquals(
+            '(' .
+            'innobackupex --no-timestamp \'./dump\' 2> /dev/null ' .
+            '&& innobackupex --apply-log \'./dump\' 2> /dev/null' .
+            ')',
+            $cmd
+        );
+    }
+
+    /**
+     * Tests XtraBackup::setUp
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testSetUpCantFindBinary()
+    {
+        $xtra = new XtraBackup();
+        $xtra->setup(array('pathToXtraBackup' => '/foo/bar'));
+    }
+
+    /**
+     * Tests XtraBackup::setUp
+     */
+    public function testSetUpFindBinary()
+    {
+        $path   = realpath(__DIR__ . '/../../../_files/bin');
+        $xtra = new XtraBackup();
+        $xtra->setup(array('pathToXtraBackup' => $path));
+
+        $this->assertTrue(true, 'no exception should be thrown');
+    }
+
+    /**
+     * Tests XtraBackup::getExec
+     */
+    public function testShowStdErr()
+    {
+        $this->xtrabackup->setup(array('showStdErr' => 'true'));
+        /** @var \phpbu\App\Backup\Cli\Exec $exec */
+        $exec = $this->xtrabackup->getExec($this->getTargetMock());
+        $cmd  = (string) $exec->getExec();
+
+        $this->assertEquals(
+            '(' .
+            'innobackupex --no-timestamp \'./dump\' ' .
+            '&& innobackupex --apply-log \'./dump\'' .
+            ')',
+            $cmd
+        );
+    }
+
+    /**
+     * Tests XtraBackup::getExec
+     */
+    public function testUser()
+    {
+        $this->xtrabackup->setup(array('user' => 'root'));
+        /** @var \phpbu\App\Backup\Cli\Exec $exec */
+        $exec = $this->xtrabackup->getExec($this->getTargetMock());
+        $cmd  = (string) $exec->getExec();
+
+        $this->assertEquals(
+            '(' .
+            'innobackupex --no-timestamp --user=\'root\' \'./dump\' 2> /dev/null ' .
+            '&& innobackupex --apply-log \'./dump\' 2> /dev/null' .
+            ')',
+            $cmd
+        );
+    }
+
+    /**
+     * Tests XtraBackup::getExec
+     */
+    public function testPassword()
+    {
+        $this->xtrabackup->setup(array('password' => 'secret'));
+        /** @var \phpbu\App\Backup\Cli\Exec $exec */
+        $exec = $this->xtrabackup->getExec($this->getTargetMock());
+        $cmd  = (string) $exec->getExec();
+
+        $this->assertEquals(
+            '(' .
+            'innobackupex --no-timestamp --password=\'secret\' \'./dump\' 2> /dev/null ' .
+            '&& innobackupex --apply-log \'./dump\' 2> /dev/null' .
+            ')',
+            $cmd
+        );
+    }
+
+    /**
+     * Tests XtraBackup::getExec
+     */
+    public function testHost()
+    {
+        $this->xtrabackup->setup(array('host' => 'example.com'));
+        /** @var \phpbu\App\Backup\Cli\Exec $exec */
+        $exec = $this->xtrabackup->getExec($this->getTargetMock());
+        $cmd  = (string) $exec->getExec();
+
+        $this->assertEquals(
+            '(' .
+            'innobackupex --no-timestamp --host=\'example.com\' \'./dump\' 2> /dev/null ' .
+            '&& innobackupex --apply-log \'./dump\' 2> /dev/null' .
+            ')',
+            $cmd
+        );
+    }
+
+    /**
+     * Tests XtraBackup::getExec
+     */
+    public function testDatabases()
+    {
+        $this->xtrabackup->setup(array('databases' => 'db1,db2,db3.table1'));
+        /** @var \phpbu\App\Backup\Cli\Exec $exec */
+        $exec = $this->xtrabackup->getExec($this->getTargetMock());
+        $cmd  = (string) $exec->getExec();
+
+        $this->assertEquals(
+            '(' .
+            'innobackupex --no-timestamp --databases=\'db1 db2 db3.table1\' \'./dump\' 2> /dev/null ' .
+            '&& innobackupex --apply-log \'./dump\' 2> /dev/null' .
+            ')',
+            $cmd
+        );
+    }
+
+    /**
+     * Tests XtraBackup::getExec
+     */
+    public function testInclude()
+    {
+        $this->xtrabackup->setup(array('include' => '^mydatabase[.]mytable'));
+        /** @var \phpbu\App\Backup\Cli\Exec $exec */
+        $exec = $this->xtrabackup->getExec($this->getTargetMock());
+        $cmd  = (string) $exec->getExec();
+
+        $this->assertEquals(
+            '(' .
+            'innobackupex --no-timestamp --include=\'^mydatabase[.]mytable\' \'./dump\' 2> /dev/null ' .
+            '&& innobackupex --apply-log \'./dump\' 2> /dev/null' .
+            ')',
+            $cmd
+        );
+    }
+
+    /**
+     * Tests XtraBackup::backup
+     */
+    public function testBackupOk()
+    {
+        $target    = $this->getTargetMock();
+        $cliResult = $this->getCliResultMock(0);
+        $appResult = $this->getMockBuilder('\\phpbu\\App\\Result')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $exec      = $this->getMockBuilder('\\phpbu\\App\\Backup\\Cli\\Exec')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+
+        $appResult->expects($this->once())->method('debug');
+        $exec->expects($this->once())->method('execute')->willReturn($cliResult);
+
+        $this->xtrabackup->setup(array());
+        $this->xtrabackup->setExec($exec);
+        $this->xtrabackup->backup($target, $appResult);
+    }
+
+    /**
+     * Tests XtraBackup::backup
+     *
+     * @expectedException \phpbu\App\Exception
+     */
+    public function testBackupFail()
+    {
+        $target    = $this->getTargetMock();
+        $cliResult = $this->getCliResultMock(1);
+        $appResult = $this->getMockBuilder('\\phpbu\\App\\Result')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $exec      = $this->getMockBuilder('\\phpbu\\App\\Backup\\Cli\\Exec')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+
+        $appResult->expects($this->once())->method('debug');
+        $exec->expects($this->once())->method('execute')->willReturn($cliResult);
+
+        $this->xtrabackup->setup(array());
+        $this->xtrabackup->setExec($exec);
+        $this->xtrabackup->backup($target, $appResult);
+    }
+
+    /**
+     * Create Cli\Result mock.
+     *
+     * @param  integer $code
+     * @return \phpbu\App\Backup\Cli\Result
+     */
+    protected function getCliResultMock($code)
+    {
+        $cliResult = $this->getMockBuilder('\\phpbu\\App\\Backup\\Cli\\Result')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+
+        $cliResult->method('getCmd')->willReturn('XtraBackup');
+        $cliResult->method('getCode')->willReturn($code);
+        $cliResult->method('getOutput')->willReturn(array());
+        $cliResult->method('wasSuccessful')->willReturn($code == 0);
+
+        return $cliResult;
+    }
+
+    /**
+     * Create Target mock.
+     *
+     * @return \phpbu\App\Backup\Target
+     */
+    protected function getTargetMock()
+    {
+        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
+                       ->disableOriginalConstructor()
+                       ->getMock();
+        $target->method('getPath')->willReturn('.');
+        $target->method('fileExists')->willReturn(false);
+        $target->method('shouldBeCompressed')->willReturn(false);
+
+        return $target;
+    }
+}


### PR DESCRIPTION
This sources uses [XtraBackup](http://www.percona.com/doc/percona-xtrabackup/) to backup MySQL databases.

XtraBackup is more efficient than `mysqldump` because it copies the database files and then replays the write-ahead log on top of the files.