### PR TITLE
Remove trailing slash from target path.

### DIFF
--- a/src/Backup/Target.php
+++ b/src/Backup/Target.php
@@ -166,7 +166,7 @@ class Target
         } else {
             $this->pathNotChanging = $path;
         }
-        $this->path = $path;
+        $this->path = rtrim($path, DIRECTORY_SEPARATOR);
     }
 
     /**

--- a/tests/phpbu/Backup/CollectorTest.php
+++ b/tests/phpbu/Backup/CollectorTest.php
@@ -101,6 +101,17 @@ class CollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(7, count($files), '7 files should be found');
     }
 
+    public function testSkipsCurrentWhenTargetPathHasTrailingBackslash()
+    {
+        $path      = $this->getTestDataDir() . '/collector/static-dir/';
+        $filename  = 'foo-%d.txt';
+        $target    = new Target($path, $filename, strtotime('2014-12-07 04:30:57'));
+        $collector = new Collector($target);
+        $files     = $collector->getBackupFiles();
+
+        $this->assertEquals(3, count($files), '3 files should be found');
+    }
+
     /**
      * Create Compressor Mock.
      *


### PR DESCRIPTION
When launch the backup with a target path with trailing slash, and is configured the quantity cleaner, the current backup is deleted in some executions when the backup quantity is exceeded, the problem is that the collector does not exclude the current backup since the result name does not match the compared one.

Maybe i should not be added the trailing slash in first place :), but this is an error hard to find and i think is better that the user does not bother about it.