### PR TITLE
Count current backup in quantity cleaning.

### DIFF
--- a/src/Backup/Cleaner/Quantity.php
+++ b/src/Backup/Cleaner/Quantity.php
@@ -62,13 +62,11 @@ class Quantity implements Cleaner
     {
         $files = $collector->getBackupFiles();
 
-        // backups exceed capacity?
-        if (count($files) > $this->amount) {
+        if ($this->isCapacityExceeded($files)) {
             // oldest backups first
             ksort($files);
 
-            // add one for current backup
-            while (count($files) + 1 > $this->amount) {
+            while ($this->isCapacityExceeded($files)) {
                 $file = array_shift($files);
                 $result->debug(sprintf('delete %s', $file->getPathname()));
                 if (!$file->isWritable()) {
@@ -78,5 +76,19 @@ class Quantity implements Cleaner
                 $file->unlink();
             }
         }
+    }
+
+    /**
+     * Returns true when the capacity is exceeded.
+     *
+     * @return boolean
+     */
+    private function isCapacityExceeded(array $files)
+    {
+        $totalFiles                  = count($files);
+        $totalFilesPlusCurrentBackup = $totalFiles + 1;
+
+        return $totalFiles > 0
+            && $totalFilesPlusCurrentBackup > $this->amount;
     }
 }

--- a/tests/phpbu/Backup/Cleaner/QuantityTest.php
+++ b/tests/phpbu/Backup/Cleaner/QuantityTest.php
@@ -139,4 +139,31 @@ class QuantityTest extends TestCase
 
         $cleaner->cleanup($targetStub, $collectorStub, $resultStub);
     }
+
+    /**
+     * Tests Capacity::cleanup
+     */
+    public function testCleanupDeleteFilesCountingCurrentBackup()
+    {
+        $fileList      = $this->getFileMockList(
+            array(
+                array('size' => 100, 'shouldBeDeleted' => true),
+            )
+        );
+        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
+                              ->getMock();
+        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
+                              ->disableOriginalConstructor()
+                              ->getMock();
+        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
+                              ->disableOriginalConstructor()
+                              ->getMock();
+
+        $collectorStub->method('getBackupFiles')->willReturn($fileList);
+
+        $cleaner = new Quantity();
+        $cleaner->setup(array('amount' => '1'));
+
+        $cleaner->cleanup($targetStub, $collectorStub, $resultStub);
+    }
 }


### PR DESCRIPTION
When the cleaning is configured for a quantity of backups, the current backup is not counted and in some executions it ends with more files than expected. This PR modifies the Quantity cleaner to count the current backup when it decides if make the cleaning or not.