### PR TITLE
Enable the realization of dumps without taking up much disk space

### DIFF
--- a/src/Backup/Source/Mysqldump.php
+++ b/src/Backup/Source/Mysqldump.php
@@ -90,6 +90,13 @@ class Mysqldump extends SimulatorExecutable implements Simulator
     private $filePerTable;
 
     /**
+     * The compressor cmd
+     *
+     * @var boolean
+     */
+    private $compressor;
+
+    /**
      * Use mysqldump quick mode
      * -q
      *
@@ -160,6 +167,7 @@ class Mysqldump extends SimulatorExecutable implements Simulator
         $this->extendedInsert  = Util\Str::toBoolean(Util\Arr::getValue($conf, 'extendedInsert', ''), false);
         $this->noData          = Util\Str::toBoolean(Util\Arr::getValue($conf, 'noData', ''), false);
         $this->filePerTable    = Util\Str::toBoolean(Util\Arr::getValue($conf, 'filePerTable', ''), false);
+        $this->compressor      = Util\Arr::getValue($conf, 'compressor', '');
 
         // this doesn't fail, but it doesn't work, so throw an exception so the user understands
         if ($this->filePerTable && count($this->structureOnly)) {
@@ -233,6 +241,10 @@ class Mysqldump extends SimulatorExecutable implements Simulator
                              ->dumpNoData($this->noData)
                              ->dumpStructureOnly($this->structureOnly)
                              ->dumpTo($this->getDumpTarget($target));
+
+            if (!empty($this->compressor)) {
+                $this->executable->getProcess()->setCompression($this->compressor);
+            }
         }
         return $this->executable;
     }

--- a/src/Cli/Process.php
+++ b/src/Cli/Process.php
@@ -30,6 +30,8 @@ class Process
      */
     private $redirectOutput;
 
+    private $sCmdCompressor;
+
     /**
      * Redirect the stdOut.
      *
@@ -38,6 +40,16 @@ class Process
     public function redirectOutputTo($path)
     {
         $this->redirectOutput = $path;
+    }
+
+    /**
+     * Set the compressor cmd
+     *
+     * @param string $cmd
+     */
+    public function setCompression($sCmdCompressor)
+    {
+        $this->sCmdCompressor = $sCmdCompressor;
     }
 
     /**
@@ -83,6 +95,7 @@ class Process
             throw new Exception('no command to execute');
         }
         $cmd = ($amount > 1 ? '(' . implode(' && ', $this->commands) . ')' : $this->commands[0])
+             . (!empty($this->sCmdCompressor) ? ' | ' . $this->sCmdCompressor : '')
              . (!empty($this->redirectOutput) ? ' > ' . $this->redirectOutput : '');
 
         return $cmd;


### PR DESCRIPTION
My server at digitalocean has a limited amount of HD and so does not support a mysqldump of all databases without immediate compacting.

To resolve the issue, i added a parameter in the mysqldump source to add a piped gzip or bzip2 in the mysqldump command.

Example:

```
"type": "mysqldump",
"options": {
     "user": "root",
     "compressor": "bzip2"
}
```

Results in:

`mysqldump -uroot | bzip2 > {destination}`

If there is a better way to solve this, please let me know.

Thank you