### PR TITLE
fix empty --limit option

### DIFF
--- a/src/Cmd.php
+++ b/src/Cmd.php
@@ -257,10 +257,8 @@ class Cmd
         $this->overrideConfigWithArgument($configuration, 'bootstrap');
 
         // check for command line limit option
-        $limit = explode(',', Arr::getValue($this->arguments, 'limit', ''));
-        if (!empty($limit)) {
-            $configuration->setLimit($limit);
-        }
+        $limitOption = Arr::getValue($this->arguments, 'limit', '');
+        $configuration->setLimit(!empty($limitOption) ? explode(',', $limitOption) : array());
 
         // add a cli printer for some output
         $configuration->addLogger(


### PR DESCRIPTION
```php
var_dump(explode(',', ''));
```

prints the following output:

```
array(1) {
  [0]=>
  string(0) ""
}
```

therefore limit is never empty during the $configuration->isBackupActive() check, which leads to phpbu currently skipping all backups if you don't explicitly set the limit-option.

checking if the limit option is empty before explode'ing will fix the issue.