### PR TITLE
Fixed mongodump --user parameter

### DIFF
--- a/src/Cli/Executable/Mongodump.php
+++ b/src/Cli/Executable/Mongodump.php
@@ -46,7 +46,7 @@ class Mongodump extends Abstraction implements Executable
 
     /**
      * User to connect with
-     * --user <username>
+     * --username <username>
      *
      * @var string
      */
@@ -229,7 +229,7 @@ class Mongodump extends Abstraction implements Executable
         $cmd->addOption('--out', $this->dumpDir, ' ');
         $cmd->addOptionIfNotEmpty('--ipv6', $this->useIPv6, false);
         $cmd->addOptionIfNotEmpty('--host', $this->host, true, ' ');
-        $cmd->addOptionIfNotEmpty('--user', $this->user, true, ' ');
+        $cmd->addOptionIfNotEmpty('--username', $this->user, true, ' ');
         $cmd->addOptionIfNotEmpty('--password', $this->password, true, ' ');
         $cmd->addOptionIfNotEmpty('--authenticationDatabase', $this->authenticationDatabase, true, ' ');
 

--- a/tests/phpbu/Cli/Executable/MongodumpTest.php
+++ b/tests/phpbu/Cli/Executable/MongodumpTest.php
@@ -44,7 +44,7 @@ class MongodumpTest extends \PHPUnit\Framework\TestCase
         $mongo = new Mongodump(PHPBU_TEST_BIN);
         $mongo->dumpToDirectory('./dump')->credentials('root');
 
-        $this->assertEquals(PHPBU_TEST_BIN . '/mongodump --out \'./dump' . '\' --user \'root\'', $mongo->getCommand());
+        $this->assertEquals(PHPBU_TEST_BIN . '/mongodump --out \'./dump' . '\' --username \'root\'', $mongo->getCommand());
     }
 
     /**


### PR DESCRIPTION
According to `mongodump` docs https://docs.mongodb.com/v3.2/reference/program/mongodump/  it hasn't parameter named `--user` but `--username` has.