### PR TITLE
Use 'createMock' and '::class' notation in tests

### DIFF
--- a/tests/phpbu/Backup/Check/SizeDiffPreviousPercentTest.php
+++ b/tests/phpbu/Backup/Check/SizeDiffPreviousPercentTest.php
@@ -19,17 +19,12 @@ class SizeDiffPreviousPercentTest extends \PHPUnit\Framework\TestCase
      */
     public function testPass()
     {
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
         $collectorStub->expects($this->once())
                       ->method('getBackupFiles')
                       ->willReturn($this->getFileListMock([100, 500, 1000]));
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
         $targetStub->method('getSize')->willReturn(1060);
 
         $check = new SizeDiffPreviousPercent();
@@ -45,17 +40,12 @@ class SizeDiffPreviousPercentTest extends \PHPUnit\Framework\TestCase
      */
     public function testFail()
     {
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
         $collectorStub->expects($this->once())
                               ->method('getBackupFiles')
                               ->willReturn($this->getFileListMock([100, 500, 1000]));
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
         $targetStub->method('getSize')->willReturn(1060);
 
         $check = new SizeDiffPreviousPercent();
@@ -76,9 +66,7 @@ class SizeDiffPreviousPercentTest extends \PHPUnit\Framework\TestCase
     {
         $list = [];
         foreach ($sizes as $i => $size) {
-            $fileStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                             ->disableOriginalConstructor()
-                             ->getMock();
+            $fileStub = $this->createMock(\phpbu\App\Backup\File::class);
             $fileStub->method('getSize')->willReturn($size);
             $list['201401' . str_pad($i + 1, 2, '0', STR_PAD_LEFT)] = $fileStub;
         }

--- a/tests/phpbu/Backup/Check/SizeMinTest.php
+++ b/tests/phpbu/Backup/Check/SizeMinTest.php
@@ -19,14 +19,9 @@ class SizeMinTest extends \PHPUnit\Framework\TestCase
      */
     public function testPass()
     {
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
         $targetStub->method('getSize')->willReturn(1030);
 
         $check = new SizeMin();

--- a/tests/phpbu/Backup/Cleaner/CapacityTest.php
+++ b/tests/phpbu/Backup/Cleaner/CapacityTest.php
@@ -49,14 +49,9 @@ class CapacityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => false],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
         $targetStub->method('getSize')->willReturn(100);
@@ -81,16 +76,11 @@ class CapacityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => false],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
         $resultStub->expects($this->exactly(2))
                    ->method('debug');
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
         $targetStub->method('getSize')->willReturn(100);
@@ -116,14 +106,9 @@ class CapacityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => false],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-            ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
         $targetStub->method('getSize')->willReturn(100);
@@ -148,14 +133,9 @@ class CapacityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => false],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->expects($this->once())->method('getBackupFiles')->willReturn($fileList);
         $targetStub->expects($this->once())->method('getSize')->willReturn(100);
@@ -180,14 +160,9 @@ class CapacityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => true],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->method('getBackupFiles')
                       ->willReturn($fileList);

--- a/tests/phpbu/Backup/Cleaner/OutdatedTest.php
+++ b/tests/phpbu/Backup/Cleaner/OutdatedTest.php
@@ -87,14 +87,9 @@ class OutdatedTest extends TestCase
                 ],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
 
@@ -133,14 +128,9 @@ class OutdatedTest extends TestCase
                 ],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->expects($this->once())->method('getBackupFiles')->willReturn($fileList);
 
@@ -172,14 +162,9 @@ class OutdatedTest extends TestCase
                 ],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
 

--- a/tests/phpbu/Backup/Cleaner/QuantityTest.php
+++ b/tests/phpbu/Backup/Cleaner/QuantityTest.php
@@ -60,14 +60,9 @@ class QuantityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => false],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->expects($this->once())
                       ->method('getBackupFiles')
@@ -94,14 +89,9 @@ class QuantityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => false],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->expects($this->once())
                       ->method('getBackupFiles')
@@ -127,14 +117,9 @@ class QuantityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => false],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->expects($this->once())
                       ->method('getBackupFiles')
@@ -156,14 +141,9 @@ class QuantityTest extends TestCase
                 ['size' => 100, 'shouldBeDeleted' => true],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->expects($this->once())
                       ->method('getBackupFiles')

--- a/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/AllTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/AllTest.php
@@ -19,9 +19,7 @@ class AllTest extends \PHPUnit\Framework\TestCase
      */
     public function testKeep()
     {
-        $file = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                     ->disableOriginalConstructor()
-                     ->getMock();
+        $file = $this->createMock(\phpbu\App\Backup\File::class);
 
         $keeper = new All();
         $this->assertTrue($keeper->keep($file));

--- a/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/NoneTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/NoneTest.php
@@ -19,9 +19,7 @@ class NoneTest extends \PHPUnit\Framework\TestCase
      */
     public function testKeep()
     {
-        $file = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                     ->disableOriginalConstructor()
-                     ->getMock();
+        $file = $this->createMock(\phpbu\App\Backup\File::class);
 
         $keeper = new None();
         $this->assertFalse($keeper->keep($file));

--- a/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/OnePerGroupTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/OnePerGroupTest.php
@@ -19,21 +19,13 @@ class OnePerGroupTest extends \PHPUnit\Framework\TestCase
      */
     public function testKeep()
     {
-        $file1 = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $file1 = $this->createMock(\phpbu\App\Backup\File::class);
 
-        $file2 = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $file2 = $this->createMock(\phpbu\App\Backup\File::class);
 
-        $file3 = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $file3 = $this->createMock(\phpbu\App\Backup\File::class);
 
-        $file4 = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $file4 = $this->createMock(\phpbu\App\Backup\File::class);
 
         $file1->method('getMTime')->willReturn(mktime(4, 10 ,0, 3, 12, 2017));
         $file2->method('getMTime')->willReturn(mktime(5, 10 ,0, 3, 12, 2017));

--- a/tests/phpbu/Backup/Cleaner/Stepwise/RangeTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/RangeTest.php
@@ -37,9 +37,7 @@ class RangeTest extends \PHPUnit\Framework\TestCase
      */
     public function testKeep()
     {
-        $fileMock = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $fileMock = $this->createMock(\phpbu\App\Backup\File::class);
         $range    = new Range(10, 5, new Keeper\All());
         $this->assertTrue($range->keep($fileMock));
     }

--- a/tests/phpbu/Backup/Cleaner/StepwiseTest.php
+++ b/tests/phpbu/Backup/Cleaner/StepwiseTest.php
@@ -78,14 +78,9 @@ class StepwiseTest extends TestCase
                 ],
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
 
@@ -119,14 +114,9 @@ class StepwiseTest extends TestCase
                 ]
             ]
         );
-        $resultStub    = $this->getMockBuilder('\\phpbu\\App\\Result')
-                              ->getMock();
-        $collectorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                              ->disableOriginalConstructor()
-                              ->getMock();
-        $targetStub    = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $resultStub    = $this->createMock(\phpbu\App\Result::class);
+        $collectorStub = $this->createMock(\phpbu\App\Backup\Collector::class);
+        $targetStub    = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $collectorStub->expects($this->once())->method('getBackupFiles')->willReturn($fileList);
 

--- a/tests/phpbu/Backup/Cleaner/TestCase.php
+++ b/tests/phpbu/Backup/Cleaner/TestCase.php
@@ -58,9 +58,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
     protected function getFileMock($size, $shouldBeDeleted, $mTime, $writable)
     {
         /* @var $fileStub \PHPUnit\Framework\MockObject */
-        $fileStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\File')
-                         ->disableOriginalConstructor()
-                         ->getMock();
+        $fileStub = $this->createMock(\phpbu\App\Backup\File::class);
         $fileStub->method('getMTime')->willReturn($mTime);
         $fileStub->method('getSize')->willReturn($size);
         $fileStub->method('isWritable')->willReturn($writable);

--- a/tests/phpbu/Backup/CliTest.php
+++ b/tests/phpbu/Backup/CliTest.php
@@ -24,7 +24,7 @@ abstract class CliTest extends \PHPUnit\Framework\TestCase
      */
     protected function getAppResultMock()
     {
-        return $this->getMockBuilder('\\phpbu\\App\\Result')->disableOriginalConstructor()->getMock();
+        return $this->createMock(\phpbu\App\Result::class);
     }
 
     /**
@@ -34,9 +34,7 @@ abstract class CliTest extends \PHPUnit\Framework\TestCase
      */
     protected function getRunnerMock()
     {
-        return $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Runner')
-                    ->disableOriginalConstructor()
-                    ->getMock();
+        return $this->createMock(\SebastianFeldmann\Cli\Command\Runner::class);
     }
 
     /**
@@ -73,9 +71,7 @@ abstract class CliTest extends \PHPUnit\Framework\TestCase
      */
     protected function getCliResultMock($code, $cmd, $output = '')
     {
-        $cliResult = $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Result')
-                          ->disableOriginalConstructor()
-                          ->getMock();
+        $cliResult = $this->createMock(\SebastianFeldmann\Cli\Command\Result::class);
 
         $cliResult->method('getCode')->willReturn($code);
         $cliResult->method('getCmd')->willReturn($cmd);
@@ -97,9 +93,7 @@ abstract class CliTest extends \PHPUnit\Framework\TestCase
     {
         $compress = !empty($fileCompressed);
         $pathName = $compress ? $fileCompressed : $file;
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
         $target->method('getPathnamePlain')->willReturn($file);
         $target->method('getPathname')->willReturn($pathName);
         $target->method('getPath')->willReturn(dirname($pathName));
@@ -119,9 +113,7 @@ abstract class CliTest extends \PHPUnit\Framework\TestCase
      */
     protected function getCompressionMock($cmd, $suffix)
     {
-        $compression = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target\\Compression')
-                            ->disableOriginalConstructor()
-                            ->getMock();
+        $compression = $this->createMock(\phpbu\App\Backup\Target\Compression::class);
         $compression->method('isPipeable')->willReturn(in_array($cmd, ['gzip', 'bzip2']));
         $compression->method('getCommand')->willReturn($cmd);
         $compression->method('getSuffix')->willReturn($suffix);

--- a/tests/phpbu/Backup/CollectorTest.php
+++ b/tests/phpbu/Backup/CollectorTest.php
@@ -138,9 +138,7 @@ class CollectorTest extends \PHPUnit\Framework\TestCase
      */
     protected function getCompressionMockForCmd($cmd, $suffix)
     {
-        $compressorStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target\\Compression')
-                               ->disableOriginalConstructor()
-                               ->getMock();
+        $compressorStub = $this->createMock(\phpbu\App\Backup\Target\Compression::class);
         $compressorStub->method('getCommand')->willReturn($cmd);
         $compressorStub->method('getSuffix')->willReturn($suffix);
 

--- a/tests/phpbu/Backup/Compressor/DirectoryTest.php
+++ b/tests/phpbu/Backup/Compressor/DirectoryTest.php
@@ -46,9 +46,7 @@ class DirectoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCanCompressUncompressedTarget()
     {
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $target->method('shouldBeCompressed')
                ->willReturn(false);
@@ -63,9 +61,7 @@ class DirectoryTest extends \PHPUnit\Framework\TestCase
     public function testGetArchiveFile()
     {
         $cmp    = Compression\Factory::create('bzip2');
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $target->method('shouldBeCompressed')
                ->willReturn(true);
@@ -89,19 +85,13 @@ class DirectoryTest extends \PHPUnit\Framework\TestCase
         $commandResult = new CommandResult('foo', 0);
         $runnerResult  = new RunnerResult($commandResult);
 
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
 
-        $runner = $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Runner')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $runner = $this->createMock(\SebastianFeldmann\Cli\Command\Runner::class);
         $runner->method('run')->willReturn($runnerResult);
 
 
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $target->method('shouldBeCompressed')
                ->willReturn(true);
@@ -128,18 +118,12 @@ class DirectoryTest extends \PHPUnit\Framework\TestCase
         $commandResult = new CommandResult('foo', 1);
         $runnerResult  = new RunnerResult($commandResult);
 
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
 
-        $runner = $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Runner')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $runner = $this->createMock(\SebastianFeldmann\Cli\Command\Runner::class);
         $runner->method('run')->willReturn($runnerResult);
 
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $target->method('shouldBeCompressed')
                ->willReturn(true);
@@ -165,18 +149,12 @@ class DirectoryTest extends \PHPUnit\Framework\TestCase
         $commandResult = new CommandResult('foo', 1);
         $runnerResult  = new RunnerResult($commandResult);
 
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
 
-        $runner = $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Runner')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $runner = $this->createMock(\SebastianFeldmann\Cli\Command\Runner::class);
         $runner->method('run')->willReturn($runnerResult);
 
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $target->method('shouldBeCompressed')
                ->willReturn(true);

--- a/tests/phpbu/Backup/Crypter/McryptTest.php
+++ b/tests/phpbu/Backup/Crypter/McryptTest.php
@@ -97,9 +97,7 @@ class McryptTest extends CliTest
         $commandResult = new CommandResult('foo', 0);
         $runnerResult  = new RunnerResult($commandResult);
 
-        $runner = $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Runner')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $runner = $this->createMock(\SebastianFeldmann\Cli\Command\Runner::class);
         $runner->method('run')->willReturn($runnerResult);
 
         $target    = $this->getTargetMock(__FILE__);
@@ -122,15 +120,11 @@ class McryptTest extends CliTest
         $commandResult = new CommandResult('foo', 1);
         $runnerResult  = new RunnerResult($commandResult);
 
-        $runner = $this->getMockBuilder('\\SebastianFeldmann\\Cli\\Command\\Runner')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $runner = $this->createMock(\SebastianFeldmann\Cli\Command\Runner::class);
         $runner->method('run')->willReturn($runnerResult);
 
         $target    = $this->getTargetMock(__FILE__);
-        $appResult = $this->getMockBuilder('\\phpbu\\App\\Result')
-                          ->disableOriginalConstructor()
-                          ->getMock();
+        $appResult = $this->createMock(\phpbu\App\Result::class);
 
         $appResult->expects($this->once())->method('debug');
 

--- a/tests/phpbu/Backup/Sync/AmazonS3v3Test.php
+++ b/tests/phpbu/Backup/Sync/AmazonS3v3Test.php
@@ -45,9 +45,7 @@ class AmazonS3v3Test extends \PHPUnit\Framework\TestCase
             'path'   => '/'
         ]);
 
-        $targetStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
         $targetStub->expects($this->once())->method('getFilename')->willReturn('foo.zip');
 
         $this->assertEquals('foo.zip', $amazonS3->getUploadPath($targetStub));
@@ -67,9 +65,7 @@ class AmazonS3v3Test extends \PHPUnit\Framework\TestCase
             'path'   => 'fiz'
         ]);
 
-        $targetStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
         $targetStub->expects($this->once())->method('getFilename')->willReturn('foo.zip');
 
         $this->assertEquals('fiz/foo.zip', $amazonS3->getUploadPath($targetStub));
@@ -89,14 +85,11 @@ class AmazonS3v3Test extends \PHPUnit\Framework\TestCase
             'path'   => '/'
         ]);
 
-        $resultStub = $this->getMockBuilder('\\phpbu\\App\\Result')
-                           ->getMock();
+        $resultStub = $this->createMock(\phpbu\App\Result::class);
         $resultStub->expects($this->once())
                    ->method('debug');
 
-        $targetStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $amazonS3->simulate($targetStub, $resultStub);
     }

--- a/tests/phpbu/Backup/Sync/DropboxTest.php
+++ b/tests/phpbu/Backup/Sync/DropboxTest.php
@@ -39,14 +39,11 @@ class DropboxTest extends \PHPUnit\Framework\TestCase
             'path'  => '/'
         ]);
 
-        $resultStub = $this->getMockBuilder('\\phpbu\\App\\Result')
-                           ->getMock();
+        $resultStub = $this->createMock(\phpbu\App\Result::class);
         $resultStub->expects($this->once())
                    ->method('debug');
 
-        $targetStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $dropbox->simulate($targetStub, $resultStub);
     }

--- a/tests/phpbu/Backup/Sync/FtpTest.php
+++ b/tests/phpbu/Backup/Sync/FtpTest.php
@@ -42,14 +42,11 @@ class FtpTest extends \PHPUnit\Framework\TestCase
             'path'     => 'foo'
         ]);
 
-        $resultStub = $this->getMockBuilder('\\phpbu\\App\\Result')
-                           ->getMock();
+        $resultStub = $this->createMock(\phpbu\App\Result::class);
         $resultStub->expects($this->once())
                    ->method('debug');
 
-        $targetStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $ftp->simulate($targetStub, $resultStub);
     }

--- a/tests/phpbu/Backup/Sync/SftpTest.php
+++ b/tests/phpbu/Backup/Sync/SftpTest.php
@@ -43,14 +43,11 @@ class SftpTest extends \PHPUnit\Framework\TestCase
             'path'     => 'foo'
         ]);
 
-        $resultStub = $this->getMockBuilder('\\phpbu\\App\\Result')
-                           ->getMock();
+        $resultStub = $this->createMock(\phpbu\App\Result::class);
         $resultStub->expects($this->once())
                    ->method('debug');
 
-        $targetStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $sftp->simulate($targetStub, $resultStub);
     }

--- a/tests/phpbu/Backup/Sync/SoftLayerTest.php
+++ b/tests/phpbu/Backup/Sync/SoftLayerTest.php
@@ -45,14 +45,11 @@ class SoftLayerTest extends \PHPUnit\Framework\TestCase
             'path'      => '/'
         ]);
 
-        $resultStub = $this->getMockBuilder('\\phpbu\\App\\Result')
-                           ->getMock();
+        $resultStub = $this->createMock(\phpbu\App\Result::class);
         $resultStub->expects($this->once())
                    ->method('debug');
 
-        $targetStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
 
         $softLayer->simulate($targetStub, $resultStub);
     }

--- a/tests/phpbu/Backup/TargetTest.php
+++ b/tests/phpbu/Backup/TargetTest.php
@@ -486,9 +486,7 @@ class TargetTest extends \PHPUnit\Framework\TestCase
      */
     protected function getCompressionMockForCmd($cmd, $suffix, $mimeType)
     {
-        $compressionStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target\\Compression')
-                                ->disableOriginalConstructor()
-                                ->getMock();
+        $compressionStub = $this->createMock(\phpbu\App\Backup\Target\Compression::class);
         $compressionStub->method('getCommand')->willReturn($cmd);
         $compressionStub->method('getSuffix')->willReturn($suffix);
         $compressionStub->method('getMimeType')->willReturn($mimeType);
@@ -504,9 +502,7 @@ class TargetTest extends \PHPUnit\Framework\TestCase
      */
     protected function getCrypterMock($suffix)
     {
-        $crypterStub = $this->getMockBuilder('\\phpbu\\App\\Backup\\Crypter')
-                            ->disableOriginalConstructor()
-                            ->getMock();
+        $crypterStub = $this->createMock(\phpbu\App\Backup\Crypter::class);
         $crypterStub->method('getSuffix')->willReturn($suffix);
 
         return $crypterStub;

--- a/tests/phpbu/Event/App/EndTest.php
+++ b/tests/phpbu/Event/App/EndTest.php
@@ -19,9 +19,7 @@ class EndTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetResult()
     {
-        $r = $this->getMockBuilder('\\phpbu\\App\\Result')
-                  ->disableOriginalConstructor()
-                  ->getMock();
+        $r = $this->createMock(\phpbu\App\Result::class);
 
         $end = new End($r);
 

--- a/tests/phpbu/Log/JsonTest.php
+++ b/tests/phpbu/Log/JsonTest.php
@@ -43,15 +43,11 @@ class JsonTest extends \PHPUnit\Framework\TestCase
         $result = $this->getResultMock();
 
         // debug event mock
-        $debugEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\Debug')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $debugEvent = $this->createMock(\phpbu\App\Event\Debug::class);
         $debugEvent->method('getMessage')->willReturn('debug');
 
         // phpbu end event mock
-        $phpbuEndEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\App\\End')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $phpbuEndEvent = $this->createMock(\phpbu\App\Event\App\End::class);
         $phpbuEndEvent->method('getResult')->willReturn($result);
 
         $json = new Json();
@@ -92,7 +88,7 @@ class JsonTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')->disableOriginalConstructor()->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         $result->method('started')->willReturn(microtime(true));
         $result->method('allOk')->willReturn(true);
         $result->method('getErrors')->willReturn([new \Exception('foo bar')]);
@@ -110,7 +106,7 @@ class JsonTest extends \PHPUnit\Framework\TestCase
      */
     protected function getBackupResultMock()
     {
-        $backup = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')->disableOriginalConstructor()->getMock();
+        $backup = $this->createMock(\phpbu\App\Result\Backup::class);
         $backup->method('getName')->willReturn('foo');
         $backup->method('wasSuccessful')->willReturn(true);
         $backup->method('checkCount')->willReturn(0);

--- a/tests/phpbu/Log/MailTest.php
+++ b/tests/phpbu/Log/MailTest.php
@@ -245,9 +245,7 @@ class MailTest extends \PHPUnit\Framework\TestCase
      */
     public function getAppResultMock()
     {
-        $appResult = $this->getMockBuilder('\\phpbu\\App\\Result')
-                          ->disableOriginalConstructor()
-                          ->getMock();
+        $appResult = $this->createMock(\phpbu\App\Result::class);
         return $appResult;
     }
 
@@ -258,9 +256,7 @@ class MailTest extends \PHPUnit\Framework\TestCase
      */
     public function getBackupResultMock()
     {
-        $backup = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $backup = $this->createMock(\phpbu\App\Result\Backup::class);
         return $backup;
     }
 
@@ -273,9 +269,7 @@ class MailTest extends \PHPUnit\Framework\TestCase
      */
     public function getExceptionMock($msg, $code)
     {
-        $e = $this->getMockBuilder('\\Exception')
-                  ->disableOriginalConstructor()
-                  ->getMock();
+        $e = $this->createMock(\Exception::class);
 
         $e->method('getMessage')->willReturn($msg);
         $e->method('getCode')->willReturn($code);
@@ -291,9 +285,8 @@ class MailTest extends \PHPUnit\Framework\TestCase
      */
     public function getEventMock($type, $arg)
     {
-        $e = $this->getMockBuilder('\\phpbu\\App\\Event\\' . $type)
-                  ->disableOriginalConstructor()
-                  ->getMock();
+        $e = $this->createMock('\\phpbu\\App\\Event\\' . $type);
+
         switch ($type) {
             case 'App\\End':
                 $e->method('getResult')->willReturn($arg);

--- a/tests/phpbu/Log/ResultFormatter/FormDataTest.php
+++ b/tests/phpbu/Log/ResultFormatter/FormDataTest.php
@@ -37,7 +37,7 @@ class FormDataTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')->disableOriginalConstructor()->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         $result->expects($this->once())->method('started')->willReturn(microtime(true));
         $result->expects($this->once())->method('allOk')->willReturn(true);
         $result->expects($this->once())->method('backupsFailedCount')->willReturn(0);
@@ -55,7 +55,7 @@ class FormDataTest extends \PHPUnit\Framework\TestCase
      */
     protected function getBackupResultMock()
     {
-        $backup = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')->disableOriginalConstructor()->getMock();
+        $backup = $this->createMock(\phpbu\App\Result\Backup::class);
         $backup->method('getName')->willReturn('foo');
         $backup->method('allOk')->willReturn(true);
         $backup->method('checkCount')->willReturn(0);

--- a/tests/phpbu/Log/ResultFormatter/JsonTest.php
+++ b/tests/phpbu/Log/ResultFormatter/JsonTest.php
@@ -40,7 +40,7 @@ class JsonTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')->disableOriginalConstructor()->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         $result->expects($this->once())->method('started')->willReturn(microtime(true));
         $result->expects($this->once())->method('allOk')->willReturn(true);
         $result->expects($this->once())->method('backupsFailedCount')->willReturn(0);
@@ -58,7 +58,7 @@ class JsonTest extends \PHPUnit\Framework\TestCase
      */
     protected function getBackupResultMock()
     {
-        $backup = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')->disableOriginalConstructor()->getMock();
+        $backup = $this->createMock(\phpbu\App\Result\Backup::class);
         $backup->expects($this->once())->method('getName')->willReturn('foo');
         $backup->expects($this->once())->method('allOk')->willReturn(true);
         $backup->expects($this->once())->method('checkCount')->willReturn(0);

--- a/tests/phpbu/Log/ResultFormatter/TemplateTest.php
+++ b/tests/phpbu/Log/ResultFormatter/TemplateTest.php
@@ -47,7 +47,7 @@ class TemplateTestTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')->disableOriginalConstructor()->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         $result->expects($this->once())->method('started')->willReturn(microtime(true));
         $result->expects($this->once())->method('allOk')->willReturn(true);
         $result->expects($this->once())->method('backupsFailedCount')->willReturn(0);
@@ -65,7 +65,7 @@ class TemplateTestTest extends \PHPUnit\Framework\TestCase
      */
     protected function getBackupResultMock()
     {
-        $backup = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')->disableOriginalConstructor()->getMock();
+        $backup = $this->createMock(\phpbu\App\Result\Backup::class);
         $backup->method('getName')->willReturn('foo');
         $backup->method('allOk')->willReturn(true);
         $backup->method('checkCount')->willReturn(0);

--- a/tests/phpbu/Log/ResultFormatter/XmlTest.php
+++ b/tests/phpbu/Log/ResultFormatter/XmlTest.php
@@ -37,7 +37,7 @@ class XmlTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')->disableOriginalConstructor()->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         $result->expects($this->once())->method('started')->willReturn(microtime(true));
         $result->expects($this->once())->method('allOk')->willReturn(true);
         $result->expects($this->once())->method('backupsFailedCount')->willReturn(0);
@@ -55,7 +55,7 @@ class XmlTest extends \PHPUnit\Framework\TestCase
      */
     protected function getBackupResultMock()
     {
-        $backup = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')->disableOriginalConstructor()->getMock();
+        $backup = $this->createMock(\phpbu\App\Result\Backup::class);
         $backup->expects($this->once())->method('getName')->willReturn('foo');
         $backup->expects($this->once())->method('allOk')->willReturn(true);
         $backup->expects($this->once())->method('checkCount')->willReturn(0);

--- a/tests/phpbu/Log/WebhookTest.php
+++ b/tests/phpbu/Log/WebhookTest.php
@@ -45,9 +45,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $result = $this->getResultMock();
 
         // phpbu end event mock
-        $phpbuEndEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\App\\End')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $phpbuEndEvent = $this->createMock(\phpbu\App\Event\App\End::class);
         $phpbuEndEvent->method('getResult')->willReturn($result);
 
         $uri  = PHPBU_TEST_FILES . '/misc/webhook.fail.uri';
@@ -68,9 +66,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $result = $this->getResultMock();
 
         // phpbu end event mock
-        $phpbuEndEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\App\\End')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $phpbuEndEvent = $this->createMock(\phpbu\App\Event\App\End::class);
         $phpbuEndEvent->method('getResult')->willReturn($result);
 
         $uri  = PHPBU_TEST_FILES . '/misc/webhook.fail.uri';
@@ -89,9 +85,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $result = $this->getResultMock();
 
         // phpbu end event mock
-        $phpbuEndEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\App\\End')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $phpbuEndEvent = $this->createMock(\phpbu\App\Event\App\End::class);
         $phpbuEndEvent->method('getResult')->willReturn($result);
 
         $uri  = PHPBU_TEST_FILES . '/misc/webhook.fake.uri';
@@ -113,9 +107,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $result = $this->getResultMock();
 
         // phpbu end event mock
-        $phpbuEndEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\App\\End')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $phpbuEndEvent = $this->createMock(\phpbu\App\Event\App\End::class);
         $phpbuEndEvent->method('getResult')->willReturn($result);
 
         $uri  = PHPBU_TEST_FILES . '/misc/webhook.fail.uri';
@@ -137,9 +129,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $result = $this->getResultMock();
 
         // phpbu end event mock
-        $phpbuEndEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\App\\End')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $phpbuEndEvent = $this->createMock(\phpbu\App\Event\App\End::class);
         $phpbuEndEvent->method('getResult')->willReturn($result);
 
         $uri  = PHPBU_TEST_FILES . '/misc/webhook.fail.uri';
@@ -164,9 +154,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
         $result = $this->getResultMock(false);
 
         // phpbu end event mock
-        $phpbuEndEvent = $this->getMockBuilder('\\phpbu\\App\\Event\\App\\End')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $phpbuEndEvent = $this->createMock(\phpbu\App\Event\App\End::class);
         $phpbuEndEvent->method('getResult')->willReturn($result);
 
         $uri  = PHPBU_TEST_FILES . '/misc/webhook.fail.uri';
@@ -185,7 +173,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock($expectCalls = true)
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')->disableOriginalConstructor()->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         if ($expectCalls) {
             $result->expects($this->once())->method('started')->willReturn(microtime(true));
             $result->expects($this->once())->method('started')->willReturn(microtime(true));
@@ -210,7 +198,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
      */
     protected function getBackupResultMock()
     {
-        $backup = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')->disableOriginalConstructor()->getMock();
+        $backup = $this->createMock(\phpbu\App\Result\Backup::class);
         $backup->method('getName')->willReturn('foo');
         $backup->method('wasSuccessful')->willReturn(true);
         $backup->method('checkCount')->willReturn(0);

--- a/tests/phpbu/Result/PrinterCliTest.php
+++ b/tests/phpbu/Result/PrinterCliTest.php
@@ -46,16 +46,12 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     public function testPhpbuStart()
     {
         $printer = new PrinterCli(false, false, false);
-        $result  = $this->getMockBuilder('\\phpbu\\App\\Result')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $result  = $this->createMock(\phpbu\App\Result::class);
         $result->expects($this->once())
                ->method('getErrors')
                ->willReturn([]);
 
-        $configuration = $this->getMockBuilder('\\phpbu\\App\\Configuration')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $configuration = $this->createMock(\phpbu\App\Configuration::class);
         $configuration->method('getFilename')
                       ->willReturn('/tmp/TestConfig.xml');
 
@@ -71,13 +67,9 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     public function testPhpbuStarVerbose()
     {
         $printer = new PrinterCli(true, false, false);
-        $result  = $this->getMockBuilder('\\phpbu\\App\\Result')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $result  = $this->createMock(\phpbu\App\Result::class);
 
-        $configuration = $this->getMockBuilder('\\phpbu\\App\\Configuration')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $configuration = $this->createMock(\phpbu\App\Configuration::class);
         $configuration->method('getFilename')->willReturn('/tmp/TestConfig.xml');
 
         ob_start();
@@ -386,12 +378,8 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     public function testPrintResultAllOk()
     {
         $printer = new PrinterCli(true, false, false);
-        $result  = $this->getMockBuilder('\\phpbu\\App\\Result')
-                        ->disableOriginalConstructor()
-                        ->getMock();
-        $backup  = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $result  = $this->createMock(\phpbu\App\Result::class);
+        $backup  = $this->createMock(\phpbu\App\Result\Backup::class);
         $result->method('getBackups')->willReturn(array($backup));
         $result->method('getErrors')->willReturn(array());
         $result->method('allOk')->willReturn(true);
@@ -418,9 +406,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     public function testPrintResultNoBackup()
     {
         $printer = new PrinterCli(false, true, false);
-        $result  = $this->getMockBuilder('\\phpbu\\App\\Result')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $result  = $this->createMock(\phpbu\App\Result::class);
 
         $result->method('getBackups')->willReturn(array());
         $result->method('getErrors')->willReturn(array());
@@ -437,13 +423,9 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     public function testPrintResultSkipped()
     {
         $printer = new PrinterCli(true, false, false);
-        $result  = $this->getMockBuilder('\\phpbu\\App\\Result')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $result  = $this->createMock(\phpbu\App\Result::class);
 
-        $backup  = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $backup  = $this->createMock(\phpbu\App\Result\Backup::class);
 
         $backup->method('allOk')->willReturn(false);
         $backup->method('wasSuccessful')->willReturn(true);
@@ -475,18 +457,12 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     public function testPrintResultFailure()
     {
         $printer = new PrinterCli(true, false, false);
-        $result  = $this->getMockBuilder('\\phpbu\\App\\Result')
-                        ->disableOriginalConstructor()
-                        ->getMock();
-        $e       = $this->getMockBuilder('\\phpbu\\App\\Exception')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $result  = $this->createMock(\phpbu\App\Result::class);
+        $e       = $this->createMock(\phpbu\App\Exception::class);
         $e->method('getMessage')->willReturn('foo');
         $e->method('getFile')->willReturn('foo.php');
         $e->method('getLine')->willReturn(1);
-        $backup  = $this->getMockBuilder('\\phpbu\\App\\Result\\Backup')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $backup  = $this->createMock(\phpbu\App\Result\Backup::class);
 
         $backup->method('allOk')->willReturn(false);
         $backup->method('wasSuccessful')->willReturn(false);
@@ -520,9 +496,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
      */
     public function getEventMock($type, $arg)
     {
-        $e = $this->getMockBuilder('\\phpbu\\App\\Event\\' . $type)
-                  ->disableOriginalConstructor()
-                  ->getMock();
+        $e = $this->createMock('\\phpbu\\App\\Event\\' . $type);
         switch ($type) {
             case 'App\\End':
                 $e->method('getResult')->willReturn($arg);

--- a/tests/phpbu/Runner/BootstrapTest.php
+++ b/tests/phpbu/Runner/BootstrapTest.php
@@ -19,9 +19,7 @@ class BootstrapTest extends \PHPUnit\Framework\TestCase
      */
     public function testBootstrapOk()
     {
-        $configuration = $this->getMockBuilder('\\phpbu\\App\\Configuration')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $configuration = $this->createMock(\phpbu\App\Configuration::class);
         $configuration->expects($this->once())
                       ->method('getBootstrap')
                       ->willReturn(PHPBU_TEST_FILES . '/misc/bootstrap.php');
@@ -39,9 +37,7 @@ class BootstrapTest extends \PHPUnit\Framework\TestCase
      */
     public function testBootstrapNoFile()
     {
-        $configuration = $this->getMockBuilder('\\phpbu\\App\\Configuration')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $configuration = $this->createMock(\phpbu\App\Configuration::class);
         $configuration->expects($this->once())
                       ->method('getBootstrap')
                       ->willReturn(PHPBU_TEST_FILES . '/misc/bootstrap_FAIL.php');

--- a/tests/phpbu/Runner/CheckTest.php
+++ b/tests/phpbu/Runner/CheckTest.php
@@ -22,9 +22,7 @@ class CheckTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckSuccessful()
     {
-        $check = $this->getMockBuilder('\\phpbu\\App\\Backup\\Check')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $check = $this->createMock(\phpbu\App\Backup\Check::class);
         $check->expects($this->once())
               ->method('pass')
               ->willReturn(true);
@@ -44,9 +42,7 @@ class CheckTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckFailed()
     {
-        $check = $this->getMockBuilder('\\phpbu\\App\\Backup\\Check')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $check = $this->createMock(\phpbu\App\Backup\Check::class);
         $check->expects($this->once())
               ->method('pass')
               ->willReturn(false);
@@ -66,9 +62,7 @@ class CheckTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckSimulationNoSimulator()
     {
-        $check = $this->getMockBuilder('\\phpbu\\App\\Backup\\Check')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $check = $this->createMock(\phpbu\App\Backup\Check::class);
 
         $target    = $this->getTargetMock();
         $result    = $this->getResultMock();
@@ -85,9 +79,7 @@ class CheckTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckSimulation()
     {
-        $check = $this->getMockBuilder('\\phpbu\\App\\Backup\\Check\\Simulator')
-                      ->disableOriginalConstructor()
-                      ->getMock();
+        $check = $this->createMock(\phpbu\App\Backup\Check\Simulator::class);
 
         $check->expects($this->once())
               ->method('simulate')
@@ -110,9 +102,7 @@ class CheckTest extends \PHPUnit\Framework\TestCase
      */
     protected function getTargetMock()
     {
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
         return $target;
     }
 
@@ -123,9 +113,7 @@ class CheckTest extends \PHPUnit\Framework\TestCase
      */
     protected function getCollectorMock()
     {
-        $collector = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-                          ->disableOriginalConstructor()
-                          ->getMock();
+        $collector = $this->createMock(\phpbu\App\Backup\Collector::class);
         return $collector;
     }
 
@@ -136,9 +124,7 @@ class CheckTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         return $result;
     }
 }

--- a/tests/phpbu/Runner/CleanerTest.php
+++ b/tests/phpbu/Runner/CleanerTest.php
@@ -22,9 +22,7 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCleanupSuccessful()
     {
-        $cleaner = $this->getMockBuilder('\\phpbu\\App\\Backup\\Cleaner')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $cleaner = $this->createMock(\phpbu\App\Backup\Cleaner::class);
         $cleaner->expects($this->once())
                 ->method('cleanup');
 
@@ -43,9 +41,7 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCleanupFailing()
     {
-        $cleaner = $this->getMockBuilder('\\phpbu\\App\\Backup\\Cleaner')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $cleaner = $this->createMock(\phpbu\App\Backup\Cleaner::class);
         $cleaner->expects($this->once())
                 ->method('cleanup')
                 ->will($this->throwException(new Exception));
@@ -63,9 +59,7 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
      */
     public function testCleanupSimulation()
     {
-        $cleaner = $this->getMockBuilder('\\phpbu\\App\\Backup\\Cleaner\\Simulator')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $cleaner = $this->createMock(\phpbu\App\Backup\Cleaner\Simulator::class);
         $cleaner->expects($this->once())
                 ->method('simulate');
 
@@ -84,9 +78,7 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
      */
     protected function getTargetMock()
     {
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
         return $target;
     }
 
@@ -97,9 +89,7 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
      */
     protected function getCollectorMock()
     {
-        $collector = $this->getMockBuilder('\\phpbu\\App\\Backup\\Collector')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $collector = $this->createMock(\phpbu\App\Backup\Collector::class);
         return $collector;
     }
 
@@ -110,9 +100,7 @@ class CleanerTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         return $result;
     }
 }

--- a/tests/phpbu/Runner/CrypterTest.php
+++ b/tests/phpbu/Runner/CrypterTest.php
@@ -22,9 +22,7 @@ class CrypterTest extends \PHPUnit\Framework\TestCase
      */
     public function testCryptSuccessful()
     {
-        $crypter = $this->getMockBuilder('\\phpbu\\App\\Backup\\Crypter')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $crypter = $this->createMock(\phpbu\App\Backup\Crypter::class);
         $crypter->expects($this->once())
                 ->method('crypt');
 
@@ -42,9 +40,7 @@ class CrypterTest extends \PHPUnit\Framework\TestCase
      */
     public function testCryptFailing()
     {
-        $crypter = $this->getMockBuilder('\\phpbu\\App\\Backup\\Crypter')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $crypter = $this->createMock(\phpbu\App\Backup\Crypter::class);
         $crypter->expects($this->once())
                 ->method('crypt')
                 ->will($this->throwException(new Exception));
@@ -61,9 +57,7 @@ class CrypterTest extends \PHPUnit\Framework\TestCase
      */
     public function testCryptSimulation()
     {
-        $crypter = $this->getMockBuilder('\\phpbu\\App\\Backup\\Crypter\\Simulator')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $crypter = $this->createMock(\phpbu\App\Backup\Crypter\Simulator::class);
         $crypter->expects($this->once())
                 ->method('simulate');
 
@@ -81,9 +75,7 @@ class CrypterTest extends \PHPUnit\Framework\TestCase
      */
     protected function getTargetMock()
     {
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
         return $target;
     }
 
@@ -94,9 +86,7 @@ class CrypterTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         return $result;
     }
 }

--- a/tests/phpbu/Runner/SourceTest.php
+++ b/tests/phpbu/Runner/SourceTest.php
@@ -22,16 +22,12 @@ class SourceTest extends \PHPUnit\Framework\TestCase
      */
     public function testBackupSuccessful()
     {
-        $status = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Status')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $status = $this->createMock(\phpbu\App\Backup\Source\Status::class);
         $status->expects($this->once())
                ->method('handledCompression')
                ->willReturn(true);
 
-        $source = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $source = $this->createMock(\phpbu\App\Backup\Source::class);
         $source->expects($this->once())
                ->method('backup')
                ->willReturn($status);
@@ -48,9 +44,7 @@ class SourceTest extends \PHPUnit\Framework\TestCase
      */
     public function testSimulateWithFileToCompress()
     {
-        $status = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Status')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $status = $this->createMock(\phpbu\App\Backup\Source\Status::class);
         $status->expects($this->once())
                ->method('handledCompression')
                ->willReturn(false);
@@ -58,9 +52,7 @@ class SourceTest extends \PHPUnit\Framework\TestCase
                ->method('getDataPath')
                ->willReturn(realpath(PHPBU_TEST_FILES . '/misc/backup.txt'));
 
-        $source = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Mysqldump')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $source = $this->createMock(\phpbu\App\Backup\Source\Mysqldump::class);
         $source->expects($this->once())
                ->method('simulate')
                ->willReturn($status);
@@ -81,9 +73,7 @@ class SourceTest extends \PHPUnit\Framework\TestCase
     public function testSimulateWithDirectoryToCompress()
     {
         $targetPath = PHPBU_TEST_FILES . '/misc';
-        $status     = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Status')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $status     = $this->createMock(\phpbu\App\Backup\Source\Status::class);
         $status->expects($this->once())
                ->method('handledCompression')
                ->willReturn(false);
@@ -94,9 +84,7 @@ class SourceTest extends \PHPUnit\Framework\TestCase
                ->method('isDirectory')
                ->willReturn(true);
 
-        $source = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Mysqldump')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $source = $this->createMock(\phpbu\App\Backup\Source\Mysqldump::class);
         $source->expects($this->once())
                ->method('simulate')
                ->willReturn($status);
@@ -121,9 +109,7 @@ class SourceTest extends \PHPUnit\Framework\TestCase
         $file           = $this->createTempFile();
         $fileCompressed = $file . '.gz';
         $targetPath     = realpath($file);
-        $status         = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Status')
-                               ->disableOriginalConstructor()
-                               ->getMock();
+        $status         = $this->createMock(\phpbu\App\Backup\Source\Status::class);
         $status->expects($this->once())
                ->method('handledCompression')
                ->willReturn(false);
@@ -131,9 +117,7 @@ class SourceTest extends \PHPUnit\Framework\TestCase
                ->method('getDataPath')
                ->willReturn($targetPath);
 
-        $source = $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Mysqldump')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $source = $this->createMock(\phpbu\App\Backup\Source\Mysqldump::class);
         $source->expects($this->once())
                ->method('backup')
                ->willReturn($status);
@@ -169,18 +153,14 @@ class SourceTest extends \PHPUnit\Framework\TestCase
      */
     protected function getTargetMock($compress, $handledCompression, $runs = 1, $cmd = 'zip', $simulate = true)
     {
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
 
         if ($compress) {
             $target->method('shouldBeCompressed')
                    ->willReturn(true);
 
             if (!$handledCompression) {
-                $compression = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target\\Compression')
-                                    ->disableOriginalConstructor()
-                                    ->getMock();
+                $compression = $this->createMock(\phpbu\App\Backup\Target\Compression::class);
                 $compression->method('getCommand')
                             ->willReturn($cmd);
 
@@ -202,9 +182,7 @@ class SourceTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock($expectedDebugCalls = 0)
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         if ($expectedDebugCalls > 0) {
             $result->expects($this->exactly($expectedDebugCalls))
                    ->method('debug');

--- a/tests/phpbu/Runner/SyncTest.php
+++ b/tests/phpbu/Runner/SyncTest.php
@@ -22,9 +22,7 @@ class SyncTest extends \PHPUnit\Framework\TestCase
      */
     public function testSyncSuccessful()
     {
-        $sync = $this->getMockBuilder('\\phpbu\\App\\Backup\\Sync')
-                     ->disableOriginalConstructor()
-                     ->getMock();
+        $sync = $this->createMock(\phpbu\App\Backup\Sync::class);
         $sync->expects($this->once())
              ->method('sync');
 
@@ -42,9 +40,7 @@ class SyncTest extends \PHPUnit\Framework\TestCase
      */
     public function testSyncFailing()
     {
-        $sync = $this->getMockBuilder('\\phpbu\\App\\Backup\\Sync')
-                     ->disableOriginalConstructor()
-                     ->getMock();
+        $sync = $this->createMock(\phpbu\App\Backup\Sync::class);
         $sync->expects($this->once())
              ->method('sync')
              ->will($this->throwException(new Exception));
@@ -61,9 +57,7 @@ class SyncTest extends \PHPUnit\Framework\TestCase
      */
     public function testSyncSimulation()
     {
-        $sync = $this->getMockBuilder('\\phpbu\\App\\Backup\\Sync\\Simulator')
-                     ->disableOriginalConstructor()
-                     ->getMock();
+        $sync = $this->createMock(\phpbu\App\Backup\Sync\Simulator::class);
         $sync->expects($this->once())
              ->method('simulate');
 
@@ -81,9 +75,7 @@ class SyncTest extends \PHPUnit\Framework\TestCase
      */
     protected function getTargetMock()
     {
-        $target = $this->getMockBuilder('\\phpbu\\App\\Backup\\Target')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $target = $this->createMock(\phpbu\App\Backup\Target::class);
         return $target;
     }
 
@@ -94,9 +86,7 @@ class SyncTest extends \PHPUnit\Framework\TestCase
      */
     protected function getResultMock()
     {
-        $result = $this->getMockBuilder('\\phpbu\\App\\Result')
-                       ->disableOriginalConstructor()
-                       ->getMock();
+        $result = $this->createMock(\phpbu\App\Result::class);
         return $result;
     }
 }

--- a/tests/phpbu/RunnerTest.php
+++ b/tests/phpbu/RunnerTest.php
@@ -146,9 +146,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
         $cleanupRunner   = $this->createCleanerRunnerMock($runCalls);
         $cleanup         = $this->createCleanerMock();
 
-        $factory = $this->getMockBuilder('\\phpbu\\App\\Factory')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $factory = $this->createMock(\phpbu\App\Factory::class);
 
         $factory->method('createRunner')
                 ->will($this->onConsecutiveCalls(
@@ -184,9 +182,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
         $checkRunner     = $this->createCheckRunnerMock(false, true);
         $check           = $this->createCheckMock();
 
-        $factory = $this->getMockBuilder('\\phpbu\\App\\Factory')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $factory = $this->createMock(\phpbu\App\Factory::class);
 
         $factory->method('createRunner')
                 ->will($this->onConsecutiveCalls(
@@ -218,9 +214,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
         $cryptRunner     = $this->createCryptRunnerMock(1, true);
         $crypt           = $this->createCryptMock();
 
-        $factory = $this->getMockBuilder('\\phpbu\\App\\Factory')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $factory = $this->createMock(\phpbu\App\Factory::class);
 
         $factory->method('createRunner')
                 ->will($this->onConsecutiveCalls(
@@ -256,9 +250,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
         $syncRunner      = $this->createSyncRunnerMock(1, true);
         $sync            = $this->createSyncMock();
 
-        $factory = $this->getMockBuilder('\\phpbu\\App\\Factory')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $factory = $this->createMock(\phpbu\App\Factory::class);
 
         $factory->method('createRunner')
                 ->will($this->onConsecutiveCalls(
@@ -298,9 +290,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
         $cleanupRunner   = $this->createCleanerRunnerMock(1, true);
         $cleanup         = $this->createCleanerMock();
 
-        $factory = $this->getMockBuilder('\\phpbu\\App\\Factory')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $factory = $this->createMock(\phpbu\App\Factory::class);
 
         $factory->method('createRunner')
                 ->will($this->onConsecutiveCalls(
@@ -334,9 +324,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
         $sourceRunner    = $this->createSourceRunnerMock(true);
         $source          = $this->createSourceMock();
 
-        $factory = $this->getMockBuilder('\\phpbu\\App\\Factory')
-                        ->disableOriginalConstructor()
-                        ->getMock();
+        $factory = $this->createMock(\phpbu\App\Factory::class);
 
         $factory->method('createRunner')
                 ->will($this->onConsecutiveCalls(
@@ -357,9 +345,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createBootstrapRunnerMock()
     {
-        $bootstrapRunner = $this->getMockBuilder('\\phpbu\\App\\Runner\\Bootstrap')
-                                ->disableOriginalConstructor()
-                                ->getMock();
+        $bootstrapRunner = $this->createMock(\phpbu\App\Runner\Bootstrap::class);
         $bootstrapRunner->expects($this->once())->method('run');
 
         return $bootstrapRunner;
@@ -383,9 +369,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createSourceRunnerMock($crash = false)
     {
-        $sourceRunner = $this->getMockBuilder('\\phpbu\\App\\Runner\\Source')
-                             ->disableOriginalConstructor()
-                             ->getMock();
+        $sourceRunner = $this->createMock(\phpbu\App\Runner\Source::class);
         if ($crash) {
             $sourceRunner->expects($this->once())->method('run')->will($this->throwException(new Exception('fail')));
         } else {
@@ -402,9 +386,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createSourceMock()
     {
-        return $this->getMockBuilder('\\phpbu\\App\\Backup\\Source\\Tar')
-                    ->disableOriginalConstructor()
-                    ->getMock();
+        return $this->createMock(\phpbu\App\Backup\Source\Tar::class);
     }
 
     /**
@@ -416,9 +398,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createCheckRunnerMock($pass, $crash = false)
     {
-        $checkRunner = $this->getMockBuilder('\\phpbu\\App\\Runner\\Check')
-                            ->disableOriginalConstructor()
-                            ->getMock();
+        $checkRunner = $this->createMock(\phpbu\App\Runner\Check::class);
         if ($crash) {
             $checkRunner->expects($this->once())->method('run')->will($this->throwException(new Exception('fail')));
         } else {
@@ -435,9 +415,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createCheckMock()
     {
-        return $this->getMockBuilder('\\phpbu\\App\\Backup\\Check\\SizeMin')
-                    ->disableOriginalConstructor()
-                    ->getMock();
+        return $this->createMock(\phpbu\App\Backup\Check\SizeMin::class);
     }
 
     /**
@@ -449,9 +427,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createCryptRunnerMock($runCalls, $crash = false)
     {
-        $cryptRunner = $this->getMockBuilder('\\phpbu\\App\\Runner\\Crypter')
-                            ->disableOriginalConstructor()
-                            ->getMock();
+        $cryptRunner = $this->createMock(\phpbu\App\Runner\Crypter::class);
 
         if ($crash) {
             $cryptRunner->expects($this->once())
@@ -471,9 +447,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createCryptMock()
     {
-        return $this->getMockBuilder('\\phpbu\\App\\Backup\\Crypter\\OpenSSL')
-                    ->disableOriginalConstructor()
-                    ->getMock();
+        return $this->createMock(\phpbu\App\Backup\Crypter\OpenSSL::class);
     }
 
     /**
@@ -485,9 +459,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createSyncRunnerMock($runCalls, $crash = false)
     {
-        $syncRunner = $this->getMockBuilder('\\phpbu\\App\\Runner\\Sync')
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $syncRunner = $this->createMock(\phpbu\App\Runner\Sync::class);
 
         if ($crash) {
             $syncRunner->expects($this->once())
@@ -507,9 +479,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createSyncMock()
     {
-        return $this->getMockBuilder('\\phpbu\\App\\Backup\\Sync\\Rsync')
-                    ->disableOriginalConstructor()
-                    ->getMock();
+        return $this->createMock(\phpbu\App\Backup\Sync\Rsync::class);
     }
 
     /**
@@ -521,9 +491,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createCleanerRunnerMock($runCalls, $crash = false)
     {
-        $cleanupRunner = $this->getMockBuilder('\\phpbu\\App\\Runner\\Cleaner')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $cleanupRunner = $this->createMock(\phpbu\App\Runner\Cleaner::class);
 
         if ($crash) {
             $cleanupRunner->expects($this->once())
@@ -543,9 +511,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
      */
     protected function createCleanerMock()
     {
-        return $cleanup = $this->getMockBuilder('\\phpbu\\App\\Backup\\Cleaner\\Outdated')
-                               ->disableOriginalConstructor()
-                               ->getMock();
+        return $cleanup = $this->createMock(\phpbu\App\Backup\Cleaner\Outdated::class);
     }
 
     /**
@@ -562,9 +528,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase
         $clean = new Configuration\Backup\Cleanup('outdated', true, []);
         $log   = new Configuration\Logger('json', []);
 
-        $configuration = $this->getMockBuilder('\\phpbu\\App\\Configuration')
-                              ->disableOriginalConstructor()
-                              ->getMock();
+        $configuration = $this->createMock(\phpbu\App\Configuration::class);
         $configuration->method('getLoggers')->willReturn([$log, $this->createLoggerMock()]);
 
         $backups = [];


### PR DESCRIPTION
Hi Sebastian. The method 'createMock' is supported since PHPUnit 5.4, thus it should be compatible with the >= 5.5 in your readme. I find the '::class' notation useful when looking for classes usages through the whole project. 