### PR TITLE
Cli.php: Altering detectCmdLocationInPaths() to check $bin variable as non-empty string instead of non-null value.

### DIFF
--- a/src/Util/Cli.php
+++ b/src/Util/Cli.php
@@ -158,7 +158,7 @@ abstract class Cli
         foreach ($paths as $path) {
             $command = $path . DIRECTORY_SEPARATOR . $cmd;
             $bin     = self::isExecutable($command);
-            if (null !== $bin) {
+            if (!empty($bin)) {
                 return $bin;
             }
         }


### PR DESCRIPTION
The isExecutable() method returns a string and in almost all of the places it's used, its return value is checked as empty/nonempty string. But the detectCmdLocationInPaths() usage checks for a non-null value.

This discrepancy is to causing my installs to not find system tools like mysqldump and gzip. The for() loop in detectCmdLocationInPaths() is ending too early (after only one iteration) and doesn't check all locations in the system path.

I've changed the detectCmdLocationInPaths() method to check the return value of isExecutable() as a string.