### PR TITLE
OpenStack sync adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If you are not using php 7.0 or greater already you can still use phpbu version 
     + rsync
     + SFTP
     + Softlayer
+    + OpenStack
 * Cleanup your local backup
     + Delete backups older x
     + Store only x MB of backups

--- a/composer.json
+++ b/composer.json
@@ -48,13 +48,15 @@
     "phpseclib/phpseclib": "~2.0",
     "softlayer/objectstorage": "dev-master",
     "vlucas/phpdotenv": "~2.4",
-    "google/apiclient":"^2.0"
+    "google/apiclient":"^2.0",
+    "php-opencloud/openstack": "^3.0"
   },
   "suggest": {
     "aws/aws-sdk-php": "Require '~3.10' to sync to Amazon S3",
     "kunalvarma05/dropbox-php-sdk": "Require '~0.2' to sync to Dropbox",
     "phpseclib/phpseclib": "Require '~2.0' to use SFTP sync",
     "softlayer/objectstorage": "Require 'dev-master' to sync to Softlayer",
+    "php-opencloud/openstack": "Require ~3.0 to sync to OpenStack",
     "vlucas/phpdotenv": "Require ~2.4 to use Dotenv adapter"
   },
   "bin": [

--- a/doc/config/sync/openstack.json
+++ b/doc/config/sync/openstack.json
@@ -1,0 +1,12 @@
+{
+  "type": "openstack",
+  "options": {
+    "auth_url": "openstack-auth-url",
+    "region": "openstack-region",
+    "username": "identify2-username",
+    "password": "identify2-password",
+    "container_name": "openstack-container-name",
+    "service_name": "cloudFiles",
+    "path": ""
+  }
+}

--- a/doc/config/sync/openstack.xml
+++ b/doc/config/sync/openstack.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sync type="openstack">
+    <!-- mandatory -->
+    <option name="auth_url" value="openstack-auth-url" />
+
+    <!-- mandatory -->
+    <option name="region" value="openstack-region" />
+
+    <!-- mandatory -->
+    <option name="username" value="identify2-username" />
+
+    <!-- mandatory -->
+    <option name="password" value="identify2-password" />
+
+    <!-- mandatory -->
+    <option name="container_name" value="backups_container" />
+
+    <!-- optional, default swift -->
+    <option name="service_name" value="swift" />
+
+    <!-- optional, default empty string -->
+    <option name="path" value="" />
+</sync>

--- a/src/Backup/Sync/Openstack.php
+++ b/src/Backup/Sync/Openstack.php
@@ -146,7 +146,7 @@ class Openstack implements Simulator
 
         $openStack = new \OpenStack\OpenStack($options);
         $objectStoreService = $openStack->objectStoreV1(['catalogName' => $this->serviceName]);
-        $container = $this->getContainer($objectStoreService);
+        $container = $this->getContainer($objectStoreService, $result);
 
         try {
             if ($target->getSize() > $this->maxStreamUploadSize) {

--- a/src/Backup/Sync/Openstack.php
+++ b/src/Backup/Sync/Openstack.php
@@ -1,0 +1,214 @@
+<?php
+namespace phpbu\App\Backup\Sync;
+
+use GuzzleHttp\Psr7\Stream;
+use OpenStack\ObjectStore\v1\Service as ObjectStoreService;
+use GuzzleHttp\Client;
+use OpenStack\Common\Transport\HandlerStack;
+use OpenStack\Common\Transport\Utils;
+use OpenStack\Identity\v2\Service;
+use phpbu\App\Backup\Target;
+use phpbu\App\Result;
+use phpbu\App\Util\Arr;
+use phpbu\App\Util\Str;
+
+/**
+ * OpenStack Swift Sync
+ *
+ * @package    phpbu
+ * @subpackage Backup
+ * @author     Vitaly Baev <hello@vitalybaev.ru>
+ * @author     Sebastian Feldmann <sebastian@phpbu.de>
+ * @copyright  Sebastian Feldmann <sebastian@phpbu.de>
+ * @license    https://opensource.org/licenses/MIT The MIT License (MIT)
+ * @link       http://phpbu.de/
+ * @since      Class available since Release 5.1
+ */
+class Openstack implements Simulator
+{
+    /**
+     * OpenStack identify url
+     *
+     * @var string
+     */
+    protected $authUrl;
+
+    /**
+     * OpenStack region
+     *
+     * @var string
+     */
+    protected $region;
+
+    /**
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * @var string
+     */
+    protected $password;
+
+    /**
+     * Object Store container name
+     *
+     * @var string
+     */
+    protected $containerName;
+
+    /**
+     * OpenStack service name
+     *
+     * @var string
+     */
+    protected $serviceName;
+
+    /**
+     * Max stream upload size, files over this size have to be uploaded as Dynamic Large Objects
+     *
+     * @var int
+     */
+    protected $maxStreamUploadSize = 5368709120;
+
+    /**
+     * Path where to copy the backup.
+     *
+     * @var string
+     */
+    protected $path = '';
+
+    /**
+     * (non-PHPDoc)
+     *
+     * @see    \phpbu\App\Backup\Sync::setup()
+     * @param  array $config
+     * @throws \phpbu\App\Backup\Sync\Exception
+     */
+    public function setup(array $config)
+    {
+        if (!class_exists('\\OpenStack\\OpenStack')) {
+            throw new Exception('OpeStack SDK not loaded: use composer to install "php-opencloud/openstack"');
+        }
+
+        // check for mandatory options
+        $this->validateConfig($config);
+
+        $this->authUrl       = $config['auth_url'];
+        $this->region        = $config['region'];
+        $this->username      = $config['username'];
+        $this->password      = $config['password'];
+        $this->containerName = $config['container_name'];
+        $this->serviceName   = Arr::getValue($config, 'service_name', 'swift');
+        if (Arr::getValue($config, 'path')) {
+            $this->path = Str::withTrailingSlash(Str::replaceDatePlaceholders($config['path']));
+            $this->path = substr($this->path, 0, 1) == '/' ? substr($this->path, 1) : $this->path;
+        }
+    }
+
+    /**
+     * Make sure all mandatory keys are present in given config.
+     *
+     * @param  array $config
+     * @throws \phpbu\App\Backup\Sync\Exception
+     */
+    protected function validateConfig(array $config)
+    {
+        foreach (['auth_url', 'region', 'username', 'password', 'container_name'] as $option) {
+            if (!Arr::isSetAndNotEmptyString($config, $option)) {
+                throw new Exception($option . ' is mandatory');
+            }
+        }
+    }
+
+    /**
+     * Execute the sync.
+     *
+     * @see    \phpbu\App\Backup\Sync::sync()
+     * @param  \phpbu\App\Backup\Target $target
+     * @param  \phpbu\App\Result        $result
+     * @throws \phpbu\App\Backup\Sync\Exception
+     */
+    public function sync(Target $target, Result $result)
+    {
+        $httpClient = new Client([
+            'base_uri' => Utils::normalizeUrl($this->authUrl),
+            'handler'  => HandlerStack::create(),
+        ]);
+
+        $options = [
+            'authUrl'         => $this->authUrl,
+            'region'          => $this->region,
+            'username'        => $this->username,
+            'password'        => $this->password,
+            'identityService' => Service::factory($httpClient),
+        ];
+
+        $openStack = new \OpenStack\OpenStack($options);
+        $objectStoreService = $openStack->objectStoreV1(['catalogName' => $this->serviceName]);
+        $container = $this->getContainer($objectStoreService);
+
+        try {
+            if ($target->getSize() > $this->maxStreamUploadSize) {
+                // use Dynamic Large Objects
+                $uploadOptions = [
+                    'name'   => $this->getUploadPath($target),
+                    'stream' => new Stream(fopen($target->getPathname(), 'r')),
+                ];
+                $container->createLargeObject($uploadOptions);
+            } else {
+                // create an object
+                $uploadOptions = [
+                    'name' => $this->getUploadPath($target),
+                    'content' => file_get_contents($target->getPathname()),
+                ];
+                $container->createObject($uploadOptions);
+            }
+        } catch (\Exception $e) {
+            throw new Exception($e->getMessage(), null, $e);
+        }
+        $result->debug('upload: done');
+    }
+
+    /**
+     * Simulate the sync execution.
+     *
+     * @param \phpbu\App\Backup\Target $target
+     * @param \phpbu\App\Result        $result
+     */
+    public function simulate(Target $target, Result $result)
+    {
+        $result->debug(
+            'sync backup to OpenStack' . PHP_EOL
+            . '  region:   ' . $this->region . PHP_EOL
+            . '  key:      ' . $this->username . PHP_EOL
+            . '  password:    ********' . PHP_EOL
+            . '  container: ' . $this->containerName
+        );
+    }
+
+    /**
+     * @param ObjectStoreService $service
+     * @return \OpenStack\ObjectStore\v1\Models\Container
+     * @throws \OpenStack\Common\Error\BadResponseError
+     */
+    protected function getContainer(ObjectStoreService $service, Result $result)
+    {
+        if (!$service->containerExists($this->containerName)) {
+            $result->debug('create container');
+            return $service->createContainer(['name' => $this->containerName]);
+        }
+        return $service->getContainer($this->containerName);
+    }
+
+    /**
+     * Get the upload path
+     *
+     * @param \phpbu\App\Backup\Target $target
+     * @return string
+     */
+    public function getUploadPath(Target $target)
+    {
+        return $this->path . $target->getFilename();
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -70,6 +70,7 @@ class Factory
             'rsync'       => '\\phpbu\\App\\Backup\\Sync\\Rsync',
             'sftp'        => '\\phpbu\\App\\Backup\\Sync\\Sftp',
             'softlayer'   => '\\phpbu\\App\\Backup\\Sync\\SoftLayer',
+            'openstack'   => '\\phpbu\\App\\Backup\\Sync\\Openstack',
         ],
         'cleaner' => [
             'capacity'  => '\\phpbu\\App\\Backup\\Cleaner\\Capacity',

--- a/tests/phpbu/Backup/Sync/OpenstackTest.php
+++ b/tests/phpbu/Backup/Sync/OpenstackTest.php
@@ -1,0 +1,180 @@
+<?php
+namespace phpbu\Backup\Sync;
+
+use phpbu\App\Backup\Sync\Openstack;
+
+/**
+ * OpenStackTest
+ *
+ * @package    phpbu
+ * @subpackage tests
+ * @author     Vitaly Baev <hello@vitalybaev.ru>
+ * @author     Sebastian Feldmann <sebastian@phpbu.de>
+ * @copyright  Sebastian Feldmann <sebastian@phpbu.de>
+ * @license    https://opensource.org/licenses/MIT The MIT License (MIT)
+ * @link       http://www.phpbu.de/
+ * @since      Class available since Release 5.1
+ */
+class OpenstackTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Tests Openstack::setUp
+     */
+    public function testSetUpOk()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'region'         => 'region-name',
+            'username'       => 'some-user',
+            'password'       => 'secret',
+            'container_name' => 'container',
+        ]);
+
+        $this->assertTrue(true, 'no exception should occur');
+    }
+
+    /**
+     * Tests Openstack::simulate
+     */
+    public function testSimulate()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'region'         => 'region-name',
+            'username'       => 'some-user',
+            'password'       => 'secret',
+            'container_name' => 'container',
+        ]);
+
+        $resultStub = $this->createMock(\phpbu\App\Result::class);
+        $resultStub->expects($this->once())
+            ->method('debug');
+
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
+
+        $openstack->simulate($targetStub, $resultStub);
+    }
+
+    /**
+     * Tests Openstack::setUp
+     *
+     * @expectedException \phpbu\App\Backup\Sync\Exception
+     */
+    public function testSetUpNoAuthUrl()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'region'         => 'region-name',
+            'username'       => 'some-user',
+            'password'       => 'secret',
+            'container_name' => 'container',
+        ]);
+    }
+
+    /**
+     * Tests Openstack::setUp
+     *
+     * @expectedException \phpbu\App\Backup\Sync\Exception
+     */
+    public function testSetUpNoRegion()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'username'       => 'some-user',
+            'password'       => 'secret',
+            'container_name' => 'container',
+        ]);
+    }
+
+    /**
+     * Tests Openstack::setUp
+     *
+     * @expectedException \phpbu\App\Backup\Sync\Exception
+     */
+    public function testSetUpNoUsername()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'region'         => 'region-name',
+            'password'       => 'secret',
+            'container_name' => 'container',
+        ]);
+    }
+
+    /**
+     * Tests Openstack::setUp
+     *
+     * @expectedException \phpbu\App\Backup\Sync\Exception
+     */
+    public function testSetUpNoPassword()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'region'         => 'region-name',
+            'username'       => 'some-user',
+            'container_name' => 'container',
+        ]);
+    }
+
+    /**
+     * Tests Openstack::setUp
+     *
+     * @expectedException \phpbu\App\Backup\Sync\Exception
+     */
+    public function testSetUpNoContainerName()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'region'         => 'region-name',
+            'username'       => 'some-user',
+            'password'       => 'secret',
+        ]);
+    }
+
+    /**
+     * Tests Openstack::getUploadPath
+     */
+    public function testGetUploadPathFixingSlashes()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'region'         => 'region-name',
+            'username'       => 'some-user',
+            'password'       => 'secret',
+            'container_name' => 'container',
+            'path'           => '/dir',
+        ]);
+
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
+        $targetStub->expects($this->once())->method('getFilename')->willReturn('foo.zip');
+
+        $this->assertEquals('dir/foo.zip', $openstack->getUploadPath($targetStub));
+    }
+
+    /**
+     * Tests Openstack::getUploadPath
+     */
+    public function testGetUploadWithEmptyPath()
+    {
+        $openstack = new Openstack();
+        $openstack->setup([
+            'auth_url'       => 'some-auth-url',
+            'region'         => 'region-name',
+            'username'       => 'some-user',
+            'password'       => 'secret',
+            'container_name' => 'container',
+        ]);
+
+        $targetStub = $this->createMock(\phpbu\App\Backup\Target::class);
+        $targetStub->expects($this->once())->method('getFilename')->willReturn('foo.zip');
+
+        $this->assertEquals('foo.zip', $openstack->getUploadPath($targetStub));
+    }
+}


### PR DESCRIPTION
OpenStack sync driver, working with identify v2 (since Rackspace and OVH still use it). Requested in #88 

Sample JSON config for Rackspace:
```
{
   "type": "openstack",
   "options": {
      "auth_url": "https://identity.api.rackspacecloud.com/v2.0",
      "region": "IAD",
      "username": "yourusername",
      "password": "your-account-password",
      "container_name": "backups",
      "path": "backups/mysql",
      "service_name": "cloudFiles"
   }
}
```

If container doesn't exist, it will be created. For files larger than 5GB Dynamic Large Objects (DLO) is used. As mentioned, this only works with phpbu `5.x` due for `php-opencloud/openstack` requires PHP 7.0 