### PR TITLE
Fixed absolute path for sftp sync

### DIFF
--- a/src/Backup/Sync/Sftp.php
+++ b/src/Backup/Sync/Sftp.php
@@ -104,11 +104,17 @@ class Sftp extends Xtp implements Simulator
      *
      * @return array
      */
-    private function getRemoteDirectoryList() : array
+    public function getRemoteDirectoryList() : array
     {
         $remoteDirs = [];
         if ('' !== $this->remotePath) {
             $remoteDirs = explode('/', $this->remotePath);
+            // if path is absolute, fix first part of array that was empty string
+            if (substr($this->remotePath, 0, 1) === '/') {
+                if (isset($remoteDirs[0])) {
+                    $remoteDirs[0] = '/';
+                }
+            }
         }
         return $remoteDirs;
     }

--- a/src/Backup/Sync/Sftp.php
+++ b/src/Backup/Sync/Sftp.php
@@ -116,6 +116,6 @@ class Sftp extends Xtp implements Simulator
                 }
             }
         }
-        return $remoteDirs;
+        return array_filter($remoteDirs);
     }
 }

--- a/tests/phpbu/Backup/Sync/SftpTest.php
+++ b/tests/phpbu/Backup/Sync/SftpTest.php
@@ -109,4 +109,19 @@ class SftpTest extends \PHPUnit\Framework\TestCase
             'path' => '/foo'
         ]);
     }
+
+    /**
+     * Tests absolute path
+     */
+    public function testSetUpPathWithAbsolutePath()
+    {
+        $sftp = new Sftp();
+        $sftp->setup([
+            'host'     => 'example.com',
+            'user'     => 'user.name',
+            'password' => 'secret',
+            'path'     => '/foo',
+        ]);
+        $this->assertEquals(['/', 'foo'], $sftp->getRemoteDirectoryList());
+    }
 }


### PR DESCRIPTION
I've realized, that if I write absolute path with SFTP sync, it doesn't work.
Problem appears because `Sftp->getRemoteDirectoryList` method exploding path with leading `/` to array with empty string as first element, causing error at `phpseclib\Net\SFTP` line 711.
Also I've added filtering empty parts of path since phpseclib causing error when it happens
