### PR TITLE
Bump symfony/event-dispatcher version to ~3.0|~4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "sebastian/environment": "~3.0|~4.0",
     "sebastianfeldmann/cli": "~3.1",
     "phpmailer/phpmailer": "~6.0",
-    "symfony/event-dispatcher": "~3.0|~4.2.0"
+    "symfony/event-dispatcher": "~3.0|~4.2"
   },
   "require-dev": {
     "sebastianfeldmann/git": "~2.2",


### PR DESCRIPTION
I had trouble installing [sebastianfeldmann/phpbu-laravel](https://github.com/sebastianfeldmann/phpbu-laravel) in a Laravel 5.8 project. `phpbu-laravel` requires `phpbu`. To me, it looks like the problem is:

```
$ composer why symfony/http-kernel
laravel/framework  v5.8.29  requires  symfony/http-kernel (^4.2)  
$ composer why symfony/event-dispatcher
symfony/http-kernel  v4.3.3  requires  symfony/event-dispatcher (^4.3)
```

So Laravel requires the most recent version of the Symfony `http-kernel`, and this in turn requires version 4.3 or higher of `symfony/event-dispatcher`.

This is why I would like to update the required version of `symfony/event-dispatcher` to `~3.0|~4.2` (hoping that this will solve my installation issue ^^).