### PR TITLE
Allow more current versions of sebastian/environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "ext-dom": "*",
     "ext-json": "*",
     "ext-spl": "*",
-    "sebastian/environment": "~3.0|~4.0",
+    "sebastian/environment": "~3.0|~4",
     "sebastianfeldmann/cli": "~3.1",
     "phpmailer/phpmailer": "~6.0",
     "symfony/event-dispatcher": "~3.0|~4.2"


### PR DESCRIPTION
Current version of `sebastian/environment` is `4.2.2`, so I updated the constraint accordingly.