### PR TITLE
Add optional color for Plan commands

### DIFF
--- a/src/Backup/Restore/Plan.php
+++ b/src/Backup/Restore/Plan.php
@@ -3,7 +3,6 @@
 
 namespace phpbu\App\Backup\Restore;
 
-
 /**
  * Class Plan
  *
@@ -66,11 +65,15 @@ class Plan
      * Add a decryption command to the restore plan
      *
      * @param  string $command
+     * @param  null|string $color
      * @return void
      */
-    public function addDecryptionCommand(string $command): void
+    public function addDecryptionCommand(string $command, string $color = null): void
     {
-        $this->commands['decrypt'][] = $command;
+        $this->commands['decrypt'][] = [
+            'color' => $color,
+            'command' => $command
+        ];
     }
 
     /**
@@ -87,11 +90,15 @@ class Plan
      * Add an decompression command to the restore plan
      *
      * @param  string $command
+     * @param  null|string $color
      * @return void
      */
-    public function addDecompressionCommand(string $command): void
+    public function addDecompressionCommand(string $command, string $color = null): void
     {
-        $this->commands['decompress'][] = $command;
+        $this->commands['decompress'][] = [
+            'color' => $color,
+            'command' => $command
+        ];
     }
 
     /**
@@ -128,11 +135,15 @@ class Plan
      * Add restore command to the restore plan
      *
      * @param  string $command
+     * @param  null|string $color
      * @return void
      */
-    public function addRestoreCommand(string $command): void
+    public function addRestoreCommand(string $command, string $color = null): void
     {
-        $this->commands['restore'][] = $command;
+        $this->commands['restore'][] = [
+            'color' => $color,
+            'command' => $command
+        ];
     }
 
     /**

--- a/src/Runner/Restore.php
+++ b/src/Runner/Restore.php
@@ -147,7 +147,11 @@ class Restore extends Process
 
         echo Util::formatWithColor('fg-yellow', "# Decrypt your backup\n");
         foreach ($commands as $cmd) {
-            echo $cmd . PHP_EOL;
+            if ($cmd['color'] == null) {
+                echo $cmd['command'] . PHP_EOL;
+                continue;
+            }
+            echo Util::formatWithColor($cmd['color'], $cmd['command']);
         }
         echo PHP_EOL;
     }
@@ -169,7 +173,11 @@ class Restore extends Process
 
         echo Util::formatWithColor('fg-yellow', "# Restore your data [BE CAREFUL]\n");
         foreach ($plan->getRestoreCommands() as $cmd) {
-            echo $cmd . PHP_EOL;
+            if ($cmd['color'] == null) {
+                echo $cmd['command'] . PHP_EOL;
+                continue;
+            }
+            echo Util::formatWithColor($cmd['color'], $cmd['command']);
         }
         echo PHP_EOL;
     }
@@ -185,7 +193,11 @@ class Restore extends Process
         if (!empty($commands)) {
             echo Util::formatWithColor('fg-yellow', "# Extract your backup \n");
             foreach ($commands as $cmd) {
-                echo $cmd . PHP_EOL;
+                if ($cmd['color'] == null) {
+                    echo $cmd['command'] . PHP_EOL;
+                    continue;
+                }
+                echo Util::formatWithColor($cmd['color'], $cmd['command']);
             }
             echo PHP_EOL;
         }


### PR DESCRIPTION
Hello @sebastianfeldmann I was working on some issues related to the restore commands, but I miss the possibility of having colored lines at the restore commands, so I would like to add this optional first and then move with few of the restore options.