### PR TITLE
Syntax Errors In Generated JSON Config

### DIFF
--- a/src/Configuration/Generator.php
+++ b/src/Configuration/Generator.php
@@ -54,10 +54,10 @@ EOT;
         "options": {
           "__FIXME__": "__FIXME__"
         }
-      }
+      },
       "target": {
         "dirname": "__FIXME__",
-        "filename": "backup-%Y%m%d-%H%i"
+        "filename": "backup-%Y%m%d-%H%i",
         "compress": "bzip2"
       }
     }


### PR DESCRIPTION
The generated JSON config was not valid, this fixes that