### PR TITLE
Check Bootstrap Is A File Before Including It

### DIFF
--- a/src/Configuration/Bootstrapper.php
+++ b/src/Configuration/Bootstrapper.php
@@ -46,7 +46,7 @@ class Bootstrapper
 
         if (!empty($filename)) {
             $pathToFile = stream_resolve_include_path($filename);
-            if (!$pathToFile || !is_readable($pathToFile)) {
+            if (!$pathToFile || !is_readable($pathToFile) || !is_file($pathToFile)) {
                 throw new Exception(sprintf('Cannot open bootstrap file "%s".' . PHP_EOL, $filename));
             }
             require $pathToFile;


### PR DESCRIPTION
Currently if the bootstrap config option is set to a directory you get an odd error message:

```
PHP Warning:  require(/.../phpbu): failed to open stream: Success in /.../phpbu/src/Configuration/Bootstrapper.php on line 52
PHP Fatal error:  require(): Failed opening required '/.../phpbu' (include_path='.:/usr/share/php') in /.../phpbu/src/Configuration/Bootstrapper.php on line 52
```

This is because the Bootstrapper class doesn't check if the argument passed is a file before requiring it. I noticed this because the default configuration generators sets the bootstrap file option to an empty string which causes this unhelpful error.

This changes means you get a nice message like this:

```
Cannot open bootstrap file "/.../phpbu/"
```

_Note: paths have been shortened for brevity_