### PR TITLE
Additional Backup Event Context

### DIFF
--- a/src/Event/Backup/Abstraction.php
+++ b/src/Event/Backup/Abstraction.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Event\Backup;
 
+use phpbu\App\Backup\Source;
+use phpbu\App\Backup\Target;
 use phpbu\App\Configuration\Backup;
 use phpbu\App\Event\Action;
 
@@ -17,13 +19,36 @@ use phpbu\App\Event\Action;
  */
 abstract class Abstraction extends Action
 {
+    private $target;
+    private $source;
+
     /**
      * Constructor.
      *
      * @param \phpbu\App\Configuration\Backup $backup
+     * @param \phpbu\App\Backup\Target $target
+     * @param \phpbu\App\Backup\Source $source
      */
-    public function __construct(Backup $backup)
+    public function __construct(Backup $backup, Target $target, Source $source)
     {
         $this->configuration = $backup;
+        $this->target = $target;
+        $this->source = $source;
+    }
+
+    /**
+     * @return \phpbu\App\Backup\Target
+     */
+    public function getTarget(): Target
+    {
+        return $this->target;
+    }
+
+    /**
+     * @return \phpbu\App\Backup\Source
+     */
+    public function getSource(): Source
+    {
+        return $this->source;
     }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App;
 
+use phpbu\App\Backup\Source;
+use phpbu\App\Backup\Target;
 use phpbu\App\Event\Dispatcher;
 
 /**
@@ -237,14 +239,16 @@ class Result
      * Backup start event
      *
      * @param  \phpbu\App\Configuration\Backup $backup
+     * @param \phpbu\App\Backup\Target $target
+     * @param \phpbu\App\Backup\Source $source
      * @throws \phpbu\App\Exception
      */
-    public function backupStart(Configuration\Backup $backup) : void
+    public function backupStart(Configuration\Backup $backup, Target $target, Source $source) : void
     {
         $this->backupActive = new Result\Backup($backup->getName());
         $this->backups[]    = $this->backupActive;
 
-        $event = new Event\Backup\Start($backup);
+        $event = new Event\Backup\Start($backup, $target, $source);
         $this->eventDispatcher->dispatch(Event\Backup\Start::NAME, $event);
     }
 
@@ -252,13 +256,15 @@ class Result
      * Backup failed event
      *
      * @param \phpbu\App\Configuration\Backup $backup
+     * @param \phpbu\App\Backup\Target $target
+     * @param \phpbu\App\Backup\Source $source
      */
-    public function backupFailed(Configuration\Backup $backup) : void
+    public function backupFailed(Configuration\Backup $backup, Target $target, Source $source) : void
     {
         $this->backupsFailed++;
         $this->backupActive->fail();
 
-        $event = new Event\Backup\Failed($backup);
+        $event = new Event\Backup\Failed($backup, $target, $source);
         $this->eventDispatcher->dispatch(Event\Backup\Failed::NAME, $event);
     }
 
@@ -276,10 +282,12 @@ class Result
      * Backup end event
      *
      * @param \phpbu\App\Configuration\Backup $backup
+     * @param \phpbu\App\Backup\Target $target
+     * @param \phpbu\App\Backup\Source $source
      */
-    public function backupEnd(Configuration\Backup $backup) : void
+    public function backupEnd(Configuration\Backup $backup, Target $target, Source $source) : void
     {
-        $event = new Event\Backup\End($backup);
+        $event = new Event\Backup\End($backup, $target, $source);
         $this->eventDispatcher->dispatch(Event\Backup\End::NAME, $event);
     }
 

--- a/src/Runner/Simulate.php
+++ b/src/Runner/Simulate.php
@@ -71,15 +71,16 @@ class Simulate extends Compression
      */
     protected function simulateSource(Configuration\Backup $conf, Target $target)
     {
-        $this->result->backupStart($conf);
         /* @var \phpbu\App\Backup\Source $runner */
         $source = $this->factory->createSource($conf->getSource()->type, $conf->getSource()->options);
+
+        $this->result->backupStart($conf, $target, $source);
 
         if ($source instanceof Source\Simulator) {
             $status = $source->simulate($target, $this->result);
             $this->compress($status, $target, $this->result);
         }
-        $this->result->backupEnd($conf);
+        $this->result->backupEnd($conf, $target, $source);
     }
 
     /**

--- a/tests/phpbu/Event/Backup/StartTest.php
+++ b/tests/phpbu/Event/Backup/StartTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Event\Backup;
 
+use phpbu\App\Backup\Source\FakeSource;
+use phpbu\App\Backup\Target;
 use phpbu\App\Configuration;
 
 /**
@@ -22,7 +24,9 @@ class StartTest extends \PHPUnit\Framework\TestCase
     public function testGetConfiguration()
     {
         $config = new Configuration\Backup('dummy', false);
-        $start  = new Start($config);
+        $target = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source = new FakeSource();
+        $start  = new Start($config, $target, $source);
         $this->assertEquals($config, $start->getConfiguration());
     }
 }

--- a/tests/phpbu/ResultTest.php
+++ b/tests/phpbu/ResultTest.php
@@ -2,6 +2,8 @@
 namespace phpbu\App;
 
 use phpbu\App\Backup\Check\Exception;
+use phpbu\App\Backup\Source\FakeSource;
+use phpbu\App\Backup\Target;
 
 /**
  * Version test
@@ -48,10 +50,12 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     {
         $conf   = new Configuration('/tmp/foo.xml');
         $backup = new Configuration\Backup('test-backup', false);
+        $target = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source = new FakeSource();
         $result = new Result();
         $result->phpbuStart($conf);
-        $result->backupStart($backup);
-        $result->backupEnd($backup);
+        $result->backupStart($backup, $target, $source);
+        $result->backupEnd($backup, $target, $source);
         $result->phpbuEnd();
 
         $this->assertTrue($result->wasSuccessful(), 'should be successful');
@@ -66,13 +70,15 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     {
         $conf    = new Configuration('/tmp/foo.xml');
         $backup  = new Configuration\Backup('test-backup', false);
+        $target  = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source  = new FakeSource();
         $check   = new Configuration\Backup\Check('sizemin', '10M');
         $crypt   = new Configuration\Backup\Crypt('mcrypt', false);
         $sync    = new Configuration\Backup\Sync('rsync', false);
         $cleanup = new Configuration\Backup\Cleanup('capacity', false);
         $result  = new Result();
         $result->phpbuStart($conf);
-        $result->backupStart($backup);
+        $result->backupStart($backup, $target, $source);
         $result->checkStart($check);
         $result->checkEnd($check);
         $result->cryptStart($crypt);
@@ -81,7 +87,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $result->syncEnd($sync);
         $result->cleanupStart($cleanup);
         $result->cleanupEnd($cleanup);
-        $result->backupEnd($backup);
+        $result->backupEnd($backup, $target, $source);
         $result->phpbuEnd();
 
         $this->assertTrue($result->wasSuccessful(), 'should be successful');
@@ -105,19 +111,21 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     {
         $conf    = new Configuration('/tmp/foo.xml');
         $backup  = new Configuration\Backup('test-backup', false);
+        $target  = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source  = new FakeSource();
         $check   = new Configuration\Backup\Check('sizemin', '10M');
         $crypt   = new Configuration\Backup\Crypt('mcrypt', false);
         $sync    = new Configuration\Backup\Sync('rsync', false);
         $cleanup = new Configuration\Backup\Cleanup('capacity', false);
         $result  = new Result();
         $result->phpbuStart($conf);
-        $result->backupStart($backup);
+        $result->backupStart($backup, $target, $source);
         $result->checkStart($check);
         $result->checkEnd($check);
         $result->cryptSkipped($crypt);
         $result->syncSkipped($sync);
         $result->cleanupSkipped($cleanup);
-        $result->backupEnd($backup);
+        $result->backupEnd($backup, $target, $source);
         $result->phpbuEnd();
 
         $this->assertTrue($result->wasSuccessful(), 'should be successful');
@@ -139,13 +147,15 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     {
         $conf    = new Configuration('/tmp/foo.xml');
         $backup  = new Configuration\Backup('test-backup', false);
+        $target  = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source  = new FakeSource();
         $check   = new Configuration\Backup\Check('sizemin', '10M');
         $crypt   = new Configuration\Backup\Crypt('mcrypt', false);
         $sync    = new Configuration\Backup\Sync('rsync', false);
         $cleanup = new Configuration\Backup\Cleanup('capacity', false);
         $result  = new Result();
         $result->phpbuStart($conf);
-        $result->backupStart($backup);
+        $result->backupStart($backup, $target, $source);
         $result->checkStart($check);
         $result->checkEnd($check);
         $result->cryptStart($crypt);
@@ -157,7 +167,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $result->cleanupStart($cleanup);
         $result->addError(new Exception('failed'));
         $result->cleanupFailed($cleanup);
-        $result->backupEnd($backup);
+        $result->backupEnd($backup, $target, $source);
         $result->phpbuEnd();
 
         $this->assertTrue($result->wasSuccessful(), 'should be successful');
@@ -180,13 +190,15 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     public function testBackupFailed()
     {
         $conf    = new Configuration('/tmp/foo.xml');
+        $target = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source = new FakeSource();
         $backup  = new Configuration\Backup('test-backup', false);
         $result  = new Result();
         $result->phpbuStart($conf);
-        $result->backupStart($backup);
+        $result->backupStart($backup, $target, $source);
         $result->addError(new Exception('failed'));
-        $result->backupFailed($backup);
-        $result->backupEnd($backup);
+        $result->backupFailed($backup, $target, $source);
+        $result->backupEnd($backup, $target, $source);
         $result->phpbuEnd();
 
         $this->assertFalse($result->wasSuccessful(), 'should be successful');
@@ -204,15 +216,17 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     {
         $conf   = new Configuration('/tmp/foo.xml');
         $backup = new Configuration\Backup('test-backup', false);
+        $target = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source = new FakeSource();
         $check  = new Configuration\Backup\Check('sizemin', '10M');
         $result = new Result();
         $result->phpbuStart($conf);
-        $result->backupStart($backup);
-        $result->backupEnd($backup);
+        $result->backupStart($backup, $target, $source);
+        $result->backupEnd($backup, $target, $source);
         $result->checkStart($check);
         $result->addError(new Exception('failed'));
         $result->checkFailed($check);
-        $result->backupEnd($backup);
+        $result->backupEnd($backup, $target, $source);
         $result->phpbuEnd();
 
         $this->assertFalse($result->wasSuccessful(), 'should be successful');
@@ -231,11 +245,13 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     {
         $conf   = new Configuration('/tmp/foo.xml');
         $backup = new Configuration\Backup('test-backup', false);
+        $target = new Target(sys_get_temp_dir() . '/test', 'targetFile');
+        $source = new FakeSource();
         $result = new Result();
         $result->phpbuStart($conf);
         $result->debug('debug');
-        $result->backupStart($backup);
-        $result->backupEnd($backup);
+        $result->backupStart($backup, $target, $source);
+        $result->backupEnd($backup, $target, $source);
         $result->phpbuEnd();
 
         // no exception party


### PR DESCRIPTION
This adds the context of the target and the source to each of the Backup events. This allows things like loggers to have much more information at their disposal. In my case I want to create a logger that can access the size of the backup

I believe this would make #183 possible.

~~I submit this as an experimental PR as I believe, in it's current state at least, will break BC~~