### PR TITLE
Require PHP Unit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ php:
 before_script:
   - composer self-update
   - composer install --no-interaction --prefer-source
-  - wget -O phpunit.phar https://phar.phpunit.de/phpunit-7.5.9.phar
   - if [ $TRAVIS_PHP_VERSION = "7.3" ]; then wget -O phpstan.phar https://github.com/phpstan/phpstan/releases/download/0.10.5/phpstan.phar ; fi
 
 script:
-  - php phpunit.phar --configuration ./build/travis-ci.phpunit.xml
+  - composer test -- --configuration ./build/travis-ci.phpunit.xml
   - if [ $TRAVIS_PHP_VERSION = "7.3" ]; then php phpstan.phar analyse --no-progress -c phpstan.neon; fi
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -166,3 +166,9 @@ Simple configuration example:
     </backups>
   </phpbu>
 ```
+
+# Development
+
+## Running Tests
+
+There is a PHP Unit test suite which can be run using `composer test`

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
     }
   },
   "scripts": {
-    "post-autoload-dump": "vendor/bin/captainhook install -f -s"
+    "post-autoload-dump": "vendor/bin/captainhook install -f -s",
+    "test": "phpunit"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
     "php-opencloud/openstack": "^3.0",
     "arhitector/yandex": "^2.0",
     "microsoft/azure-storage-blob": "^1.4",
-    "captainhook/captainhook": "^5.0"
+    "captainhook/captainhook": "^5.0",
+    "phpunit/phpunit": "^8.5"
   },
   "suggest": {
     "sebastianfeldmann/ftp": "Require ^0.9 to sync to an FTP server",


### PR DESCRIPTION
This adds:

- PHP Unit as a Composer dev dependency
- A Composer script to make tests easy to run
- Some docs to the README about the above