### PR TITLE
Removes PHP7.4 Feature Usage

### DIFF
--- a/src/Cli/Executable/Rsync/Location.php
+++ b/src/Cli/Executable/Rsync/Location.php
@@ -91,13 +91,9 @@ class Location
      * Magic to string method
      *
      * @return string
-     * @throws \phpbu\App\Exception
      */
     public function __toString()
     {
-        if (!$this->isValid()) {
-            throw new Exception('invalid rsync path');
-        }
         $return = '';
         if (!empty($this->host)) {
             // remote user

--- a/tests/phpbu/Cli/Executable/Rsync/LocationTest.php
+++ b/tests/phpbu/Cli/Executable/Rsync/LocationTest.php
@@ -17,16 +17,6 @@ class LocationTest extends \PHPUnit\Framework\TestCase
     /**
      * Tests Rsync::toString
      */
-    public function testEmptyOnInit()
-    {
-        $this->expectException('phpbu\App\Exception');
-        $location = new Location();
-        $location->toString();
-    }
-
-    /**
-     * Tests Rsync::toString
-     */
     public function testHostAndPath()
     {
         $location = new Location();


### PR DESCRIPTION
This removes an exception which is being thrown in a `__toString` method which is a PHP7.4 only feature. This closes #241