### PR TITLE
Updates Webhooks To Use Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
   },
   "suggest": {
     "sebastianfeldmann/ftp": "Require ^0.9 to sync to an FTP server",
-    "guzzlehttp/guzzle": "Require ^5.3.3|^6.2.1 to write logs to Telegram",
+    "guzzlehttp/guzzle": "Require ^5.3.3|^6.2.1 to write logs to Telegram or send webhooks",
     "aws/aws-sdk-php": "Require '^3.10' to sync to Amazon S3",
     "kunalvarma05/dropbox-php-sdk": "Require '^0.2' to sync to Dropbox",
     "phpseclib/phpseclib": "Require '^2.0' to use SFTP sync",


### PR DESCRIPTION
This PR replace the use of `file_get_contents` with Guzzle when sending wehbooks, the benefits of this are:

- We no longer rely on the [`allow_url_fopen`](https://www.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen) ini setting being set to `true` (which IMO it never should be)
- The tests aren't all expecting exceptions
- Previously if the webhook responded with a non-200 response no message would be shown
- The error messages when webhooks fail are much more descriptive:
  - `could not reach webhook: http://localhost/ (cURL error 28: Operation timed out...`
  - `could not reach webhook: http://localhost (cURL error 6: Could not resolve host:...`
  - `webhook failed: http://localhost:33343/server.php (500 Internal Server Error)`
  - `webhook failed: http://localhost:33343/server.php (401 Unauthorized)`