### PR TITLE
Improve test stuffs

### DIFF
--- a/tests/phpbu/Adapter/DotEnvTest.php
+++ b/tests/phpbu/Adapter/DotEnvTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Adapter;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Factory test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Adapter;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class DotenvTest extends \PHPUnit\Framework\TestCase
+class DotenvTest extends TestCase
 {
     /**
      * Tests DotEnv::setUp

--- a/tests/phpbu/Adapter/EnvTest.php
+++ b/tests/phpbu/Adapter/EnvTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Adapter;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Env test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Adapter;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 4.0.0
  */
-class EnvTest extends \PHPUnit\Framework\TestCase
+class EnvTest extends TestCase
 {
     /**
      * Tests Env::setup

--- a/tests/phpbu/Adapter/PHPArrayTest.php
+++ b/tests/phpbu/Adapter/PHPArrayTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Adapter;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Env test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Adapter;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 4.0.0
  */
-class PHPArrayTest extends \PHPUnit\Framework\TestCase
+class PHPArrayTest extends TestCase
 {
     /**
      * Tests PHPArray::setup

--- a/tests/phpbu/Adapter/UtilTest.php
+++ b/tests/phpbu/Adapter/UtilTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Adapter;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Adapter Util test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Adapter;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.7
  */
-class UtilTest extends \PHPUnit\Framework\TestCase
+class UtilTest extends TestCase
 {
     /**
      * Tests Util::getAdapterReplacements
@@ -21,7 +23,7 @@ class UtilTest extends \PHPUnit\Framework\TestCase
     {
         $values = Util::getAdapterReplacements('adapter:foo:bar');
 
-        $this->assertEquals(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertEquals('adapter:foo:bar', $values[0]['search']);
         $this->assertEquals('foo', $values[0]['adapter']);
         $this->assertEquals('bar', $values[0]['path']);
@@ -34,7 +36,7 @@ class UtilTest extends \PHPUnit\Framework\TestCase
     {
         $values = Util::getAdapterReplacements(':AdaPteR:foo:bar');
 
-        $this->assertEquals(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertEquals(':AdaPteR:foo:bar', $values[0]['search']);
         $this->assertEquals('foo', $values[0]['adapter']);
         $this->assertEquals('bar', $values[0]['path']);
@@ -47,7 +49,7 @@ class UtilTest extends \PHPUnit\Framework\TestCase
     {
         $values = Util::getAdapterReplacements('adapter:foo:bar:');
 
-        $this->assertEquals(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertEquals('adapter:foo:bar:', $values[0]['search']);
         $this->assertEquals('foo', $values[0]['adapter']);
         $this->assertEquals('bar', $values[0]['path']);
@@ -60,7 +62,7 @@ class UtilTest extends \PHPUnit\Framework\TestCase
     {
         $values = Util::getAdapterReplacements(':adapter:foo:bar:');
 
-        $this->assertEquals(1, count($values));
+        $this->assertCount(1, $values);
         $this->assertEquals(':adapter:foo:bar:', $values[0]['search']);
         $this->assertEquals('foo', $values[0]['adapter']);
         $this->assertEquals('bar', $values[0]['path']);
@@ -73,7 +75,7 @@ class UtilTest extends \PHPUnit\Framework\TestCase
     {
         $values = Util::getAdapterReplacements('adapter:foo:bar:/some/path/:adapter:fiz:baz');
 
-        $this->assertEquals(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertEquals('adapter:foo:bar:', $values[0]['search']);
         $this->assertEquals('foo', $values[0]['adapter']);
         $this->assertEquals('bar', $values[0]['path']);
@@ -90,7 +92,7 @@ class UtilTest extends \PHPUnit\Framework\TestCase
     {
         $values = Util::getAdapterReplacements('/some/:adapter:foo:bar:/path/:adapter:fiz:baz:/end/');
 
-        $this->assertEquals(2, count($values));
+        $this->assertCount(2, $values);
         $this->assertEquals(':adapter:foo:bar:', $values[0]['search']);
         $this->assertEquals('foo', $values[0]['adapter']);
         $this->assertEquals('bar', $values[0]['path']);

--- a/tests/phpbu/Backup/Check/SizeMinTest.php
+++ b/tests/phpbu/Backup/Check/SizeMinTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Check;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * SizeMinTest
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Check;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class SizeMinTest extends \PHPUnit\Framework\TestCase
+class SizeMinTest extends TestCase
 {
     /**
      * Tests SizeMin::pass

--- a/tests/phpbu/Backup/Cleaner/OutdatedTest.php
+++ b/tests/phpbu/Backup/Cleaner/OutdatedTest.php
@@ -90,7 +90,7 @@ class OutdatedTest extends TestCase
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
 
         $cleaner = new Outdated();
-        $cleaner->setup(array('older' => '3d'));
+        $cleaner->setup(['older' => '3d']);
 
         $cleaner->cleanup($targetStub, $collectorStub, $resultStub);
     }
@@ -164,7 +164,7 @@ class OutdatedTest extends TestCase
         $collectorStub->method('getBackupFiles')->willReturn($fileList);
 
         $cleaner = new Outdated();
-        $cleaner->setup(array('older' => '3d'));
+        $cleaner->setup(['older' => '3d']);
 
         $cleaner->cleanup($targetStub, $collectorStub, $resultStub);
     }

--- a/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/AllTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/AllTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Cleaner\Stepwise\Keeper;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * All test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Cleaner\Stepwise\Keeper;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class AllTest extends \PHPUnit\Framework\TestCase
+class AllTest extends TestCase
 {
     /**
      * Tests All::keep

--- a/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/NoneTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/NoneTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Cleaner\Stepwise\Keeper;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * All test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Cleaner\Stepwise\Keeper;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class NoneTest extends \PHPUnit\Framework\TestCase
+class NoneTest extends TestCase
 {
     /**
      * Tests None::keep

--- a/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/OnePerGroupTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/Keeper/OnePerGroupTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Cleaner\Stepwise\Keeper;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * OnePerGroup test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Cleaner\Stepwise\Keeper;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class OnePerGroupTest extends \PHPUnit\Framework\TestCase
+class OnePerGroupTest extends TestCase
 {
     /**
      * Tests OnePerGroup::keep

--- a/tests/phpbu/Backup/Cleaner/Stepwise/RangeTest.php
+++ b/tests/phpbu/Backup/Cleaner/Stepwise/RangeTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Cleaner\Stepwise;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Range test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Cleaner\Stepwise;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class RangeTest extends \PHPUnit\Framework\TestCase
+class RangeTest extends TestCase
 {
     /**
      * Tests Range::getStart

--- a/tests/phpbu/Backup/Cleaner/TestCase.php
+++ b/tests/phpbu/Backup/Cleaner/TestCase.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Cleaner;
 
 use phpbu\App\Backup\File\Local;
 use phpbu\App\Util\Str;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**
  * TestCase
@@ -15,7 +16,7 @@ use phpbu\App\Util\Str;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class TestCase extends \PHPUnit\Framework\TestCase
+class TestCase extends PHPUnitTestCase
 {
     /**
      * Test execution time

--- a/tests/phpbu/Backup/Collector/LocalTest.php
+++ b/tests/phpbu/Backup/Collector/LocalTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Backup\Collector;
 
 use phpbu\App\Backup\Target;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Local test
@@ -14,7 +15,7 @@ use phpbu\App\Backup\Target;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class LocalTest extends \PHPUnit\Framework\TestCase
+class LocalTest extends TestCase
 {
     /**
      * Test the Backup collector with no dynamic directory
@@ -28,7 +29,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(4, count($files), '4 files should be found');
+        $this->assertCount(4, $files, '4 files should be found');
     }
 
     /**
@@ -44,7 +45,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(4, count($files), '4 files should be found');
+        $this->assertCount(4, $files, '4 files should be found');
     }
 
     /**
@@ -61,7 +62,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(3, count($files), '3 files should be found');
+        $this->assertCount(3, $files, '3 files should be found');
     }
 
     /**
@@ -75,7 +76,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(4, count($files), '4 files should be found');
+        $this->assertCount(4, $files, '4 files should be found');
     }
 
     /**
@@ -89,7 +90,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(8, count($files), '8 files should be found');
+        $this->assertCount(8, $files, '8 files should be found');
     }
 
     /**
@@ -103,7 +104,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(2, count($files), '2 files should be found');
+        $this->assertCount(2, $files, '2 files should be found');
     }
 
     /**
@@ -119,7 +120,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(7, count($files), '5 files should be found');
+        $this->assertCount(7, $files, '5 files should be found');
     }
 
     /**
@@ -133,7 +134,7 @@ class LocalTest extends \PHPUnit\Framework\TestCase
         $collector = new Local($target);
         $files     = $collector->getBackupFiles();
 
-        $this->assertEquals(4, count($files), '4 files should be found');
+        $this->assertCount(4, $files, '4 files should be found');
     }
 
     /**

--- a/tests/phpbu/Backup/Compressor/DirectoryTest.php
+++ b/tests/phpbu/Backup/Compressor/DirectoryTest.php
@@ -4,6 +4,7 @@ namespace phpbu\App\Backup\Compressor;
 use phpbu\App\Backup\Target\Compression;
 use SebastianFeldmann\Cli\Command\Result as CommandResult;
 use SebastianFeldmann\Cli\Command\Runner\Result as RunnerResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Compressor test
@@ -16,7 +17,7 @@ use SebastianFeldmann\Cli\Command\Runner\Result as RunnerResult;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class DirectoryTest extends \PHPUnit\Framework\TestCase
+class DirectoryTest extends TestCase
 {
     /**
      * Tests Directory:__construct

--- a/tests/phpbu/Backup/Compressor/FileTest.php
+++ b/tests/phpbu/Backup/Compressor/FileTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Compressor;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * File compressor test.
@@ -15,7 +16,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class FileTest extends \PHPUnit\Framework\TestCase
+class FileTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Crypter/McryptTest.php
+++ b/tests/phpbu/Backup/Crypter/McryptTest.php
@@ -6,6 +6,7 @@ use phpbu\App\BaseMockery;
 use phpbu\App\Configuration;
 use SebastianFeldmann\Cli\Command\Result as CommandResult;
 use SebastianFeldmann\Cli\Command\Runner\Result as RunnerResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * McryptTest
@@ -18,7 +19,7 @@ use SebastianFeldmann\Cli\Command\Runner\Result as RunnerResult;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class McryptTest extends \PHPUnit\Framework\TestCase
+class McryptTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/File/DropboxTest.php
+++ b/tests/phpbu/Backup/File/DropboxTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\File;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * DropboxTest
  *
@@ -13,7 +15,7 @@ namespace phpbu\App\Backup\File;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class DropboxTest extends \PHPUnit\Framework\TestCase
+class DropboxTest extends TestCase
 {
     /**
      * Test creating file and handle removing

--- a/tests/phpbu/Backup/File/FtpTest.php
+++ b/tests/phpbu/Backup/File/FtpTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Backup\File;
 
 use SebastianFeldmann;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FtpTest
@@ -15,7 +16,7 @@ use SebastianFeldmann;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class FtpTest extends \PHPUnit\Framework\TestCase
+class FtpTest extends TestCase
 {
     /**
      * Test creating file and handle removing

--- a/tests/phpbu/Backup/File/GoogleDriveTest.php
+++ b/tests/phpbu/Backup/File/GoogleDriveTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\File;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Google Drive file test.
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\File;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class GoogleDriveTest extends \PHPUnit\Framework\TestCase
+class GoogleDriveTest extends TestCase
 {
     /**
      * Test GoogleDrive::unlink

--- a/tests/phpbu/Backup/File/OpenStackTest.php
+++ b/tests/phpbu/Backup/File/OpenStackTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\File;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * OpenStackTest
  *
@@ -13,7 +15,7 @@ namespace phpbu\App\Backup\File;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class OpenStackTest extends \PHPUnit\Framework\TestCase
+class OpenStackTest extends TestCase
 {
     public function testCreateFileWithCorrectProperties()
     {

--- a/tests/phpbu/Backup/File/SftpTest.php
+++ b/tests/phpbu/Backup/File/SftpTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\File;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * SftpTest
  *
@@ -13,7 +15,7 @@ namespace phpbu\App\Backup\File;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class SftpTest extends \PHPUnit\Framework\TestCase
+class SftpTest extends TestCase
 {
     /**
      * Test creating file and handle removing
@@ -37,7 +39,7 @@ class SftpTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('/backups/dump.tar.gz', $file->getPathname());
         $this->assertEquals(102102, $file->getSize());
         $this->assertEquals(1525788894, $file->getMTime());
-        $this->assertEquals(true, $file->isWritable());
+        $this->assertTrue($file->isWritable());
 
         $file->unlink();
         $this->assertTrue(true, 'no exception should occur');

--- a/tests/phpbu/Backup/File/SimulationTest.php
+++ b/tests/phpbu/Backup/File/SimulationTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\File;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * SimulationTest
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\File;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class SimulationTest extends \PHPUnit\Framework\TestCase
+class SimulationTest extends TestCase
 {
     /**
      * Test creating file and handle removing
@@ -37,7 +39,7 @@ class SimulationTest extends \PHPUnit\Framework\TestCase
         $time = time();
         $file = new Simulation($time, 100, '/foo', 'bar.txt');
 
-        $this->assertEquals(true, $file->isWritable());
+        $this->assertTrue($file->isWritable());
 
         $file->unlink();
         $this->assertTrue(true, 'no exception should be thrown');

--- a/tests/phpbu/Backup/FileTest.php
+++ b/tests/phpbu/Backup/FileTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Backup;
 
 use phpbu\App\Backup\File\Local;
+use PHPUnit\Framework\TestCase;
 
 /**
  * File test
@@ -15,7 +16,7 @@ use phpbu\App\Backup\File\Local;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class FileTest extends \PHPUnit\Framework\TestCase
+class FileTest extends TestCase
 {
     /**
      * Tests File::getFileInfo
@@ -100,7 +101,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
 
         unlink($spl->getPathname());
 
-        $this->assertEquals(true, $writable);
+        $this->assertTrue($writable);
     }
 
     /**
@@ -114,7 +115,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
 
         $existing = file_exists($spl->getPathname());
 
-        $this->assertEquals(false, $existing);
+        $this->assertFalse($existing);
     }
 
     /**

--- a/tests/phpbu/Backup/PathTest.php
+++ b/tests/phpbu/Backup/PathTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Path test
  *
@@ -13,7 +15,7 @@ namespace phpbu\App\Backup;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class PathTest extends \PHPUnit\Framework\TestCase
+class PathTest extends TestCase
 {
     /**
      * Tests Path::getPath

--- a/tests/phpbu/Backup/Source/ArangodumpTest.php
+++ b/tests/phpbu/Backup/Source/ArangodumpTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Arangodump Source Test
@@ -16,7 +17,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class ArangodumpTest extends \PHPUnit\Framework\TestCase
+class ArangodumpTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Source/ElasticdumpTest.php
+++ b/tests/phpbu/Backup/Source/ElasticdumpTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Elasticdump Source Test
@@ -16,7 +17,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class ElasticdumpTest extends \PHPUnit\Framework\TestCase
+class ElasticdumpTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Source/InfluxdumpTest.php
+++ b/tests/phpbu/Backup/Source/InfluxdumpTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * InfluxdumpTest
@@ -15,7 +16,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 2.1.12
  */
-class InfluxdumpTest extends \PHPUnit\Framework\TestCase
+class InfluxdumpTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;
@@ -113,7 +114,7 @@ class InfluxdumpTest extends \PHPUnit\Framework\TestCase
         try {
             $influxd->backup($target, $appResult);
         } catch (\Exception $e) {
-            $this->assertFalse(file_exists($file));
+            $this->assertFileNotExists($file);
             throw $e;
         }
     }

--- a/tests/phpbu/Backup/Source/LdapdumpTest.php
+++ b/tests/phpbu/Backup/Source/LdapdumpTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * LdapdumpTest
@@ -16,7 +17,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 2.1.12
  */
-class LdapdumpTest extends \PHPUnit\Framework\TestCase
+class LdapdumpTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;
@@ -198,7 +199,7 @@ class LdapdumpTest extends \PHPUnit\Framework\TestCase
         try {
             $ldap->backup($target, $appResult);
         } catch (\Exception $e) {
-            $this->assertFalse(file_exists($file));
+            $this->assertFileNotExists($file);
             throw $e;
         }
     }

--- a/tests/phpbu/Backup/Source/MongodumpTest.php
+++ b/tests/phpbu/Backup/Source/MongodumpTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * MongodumpTest
@@ -15,7 +16,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 1.1.6
  */
-class MongodumpTest extends \PHPUnit\Framework\TestCase
+class MongodumpTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Source/MysqldumpTest.php
+++ b/tests/phpbu/Backup/Source/MysqldumpTest.php
@@ -324,7 +324,7 @@ class MysqldumpTest extends TestCase
         try {
             $mysqldump->backup($target, $appResult);
         } catch (Exception $e) {
-            $this->assertFalse(file_exists($file));
+            $this->assertFileNotExists($file);
             throw $e;
         }
     }

--- a/tests/phpbu/Backup/Source/PgdumpTest.php
+++ b/tests/phpbu/Backup/Source/PgdumpTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Pgdump Test
@@ -15,7 +16,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 3.0.0
  */
-class PgdumpTest extends \PHPUnit\Framework\TestCase
+class PgdumpTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Source/RedisTest.php
+++ b/tests/phpbu/Backup/Source/RedisTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * RedisTest
@@ -15,7 +16,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 2.1.12
  */
-class RedisTest extends \PHPUnit\Framework\TestCase
+class RedisTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;
@@ -69,7 +70,7 @@ class RedisTest extends \PHPUnit\Framework\TestCase
         $status = $redis->backup($target, $appResult);
 
         $this->assertEquals('/tmp/dump.rdb', $status->getDataPath());
-        $this->assertEquals(false, $status->handledCompression());
+        $this->assertFalse($status->handledCompression());
     }
 
     /**

--- a/tests/phpbu/Backup/Source/RsyncTest.php
+++ b/tests/phpbu/Backup/Source/RsyncTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * RsyncTest
@@ -15,7 +16,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 3.2.0
  */
-class RsyncTest extends \PHPUnit\Framework\TestCase
+class RsyncTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Source/StatusTest.php
+++ b/tests/phpbu/Backup/Source/StatusTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Source;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Status Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Source;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.1
  */
-class StatusTest extends \PHPUnit\Framework\TestCase
+class StatusTest extends TestCase
 {
     /**
      * Tests Status::create

--- a/tests/phpbu/Backup/Source/TarTest.php
+++ b/tests/phpbu/Backup/Source/TarTest.php
@@ -6,6 +6,7 @@ use phpbu\App\BaseMockery;
 use SebastianFeldmann\Cli\Command\Result as CommandResult;
 use SebastianFeldmann\Cli\Command\Runner\Simple;
 use SebastianFeldmann\Cli\Processor\ProcOpen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * TarTest
@@ -18,7 +19,7 @@ use SebastianFeldmann\Cli\Processor\ProcOpen;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class TarTest extends \PHPUnit\Framework\TestCase
+class TarTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Source/XtraBackupTest.php
+++ b/tests/phpbu/Backup/Source/XtraBackupTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Source;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * XtraBackup Source Test
@@ -16,7 +17,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class XtraBackupTest extends \PHPUnit\Framework\TestCase
+class XtraBackupTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Sync/AmazonS3v3Test.php
+++ b/tests/phpbu/Backup/Sync/AmazonS3v3Test.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Backup\Sync;
 
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * AmazonS3Test
@@ -14,7 +15,7 @@ use phpbu\App\BaseMockery;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class AmazonS3v3Test extends \PHPUnit\Framework\TestCase
+class AmazonS3v3Test extends TestCase
 {
     use BaseMockery;
 

--- a/tests/phpbu/Backup/Sync/AzureBlobTest.php
+++ b/tests/phpbu/Backup/Sync/AzureBlobTest.php
@@ -5,6 +5,7 @@ use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use MicrosoftAzure\Storage\Blob\Models\ListBlobsResult;
 use MicrosoftAzure\Storage\Blob\Models\ListContainersResult;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * AzureBlobTest
@@ -18,7 +19,7 @@ use phpbu\App\BaseMockery;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.2.7
  */
-class AzureBlobTest extends \PHPUnit\Framework\TestCase
+class AzureBlobTest extends TestCase
 {
     use BaseMockery;
 

--- a/tests/phpbu/Backup/Sync/DropboxTest.php
+++ b/tests/phpbu/Backup/Sync/DropboxTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Backup\Sync;
 
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * DropboxTest
@@ -14,7 +15,7 @@ use phpbu\App\BaseMockery;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class DropboxTest extends \PHPUnit\Framework\TestCase
+class DropboxTest extends TestCase
 {
     use BaseMockery;
 

--- a/tests/phpbu/Backup/Sync/FtpTest.php
+++ b/tests/phpbu/Backup/Sync/FtpTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Backup\Sync;
 
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FtpTest
@@ -13,7 +14,7 @@ use phpbu\App\BaseMockery;
  * @license    https://opensource.org/licenses/MIT The MIT License (MIT)
  * @link       http://www.phpbu.de/
  */
-class FtpTest extends \PHPUnit\Framework\TestCase
+class FtpTest extends TestCase
 {
     use BaseMockery;
 

--- a/tests/phpbu/Backup/Sync/GoogleDriveTest.php
+++ b/tests/phpbu/Backup/Sync/GoogleDriveTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Backup\Sync;
 
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Google Drive sync test.
@@ -14,7 +15,7 @@ use phpbu\App\BaseMockery;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.0
  */
-class GoogleDriveTest extends \PHPUnit\Framework\TestCase
+class GoogleDriveTest extends TestCase
 {
     use BaseMockery;
 

--- a/tests/phpbu/Backup/Sync/OpenStackTest.php
+++ b/tests/phpbu/Backup/Sync/OpenStackTest.php
@@ -3,6 +3,7 @@ namespace phpbu\Backup\Sync;
 
 use phpbu\App\Backup\Sync\Exception;
 use phpbu\App\Backup\Sync\OpenStack;
+use PHPUnit\Framework\TestCase;
 
 /**
  * OpenStackTest
@@ -16,7 +17,7 @@ use phpbu\App\Backup\Sync\OpenStack;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1
  */
-class OpenStackTest extends \PHPUnit\Framework\TestCase
+class OpenStackTest extends TestCase
 {
     /**
      * Tests OpenStack::setUp

--- a/tests/phpbu/Backup/Sync/RsyncTest.php
+++ b/tests/phpbu/Backup/Sync/RsyncTest.php
@@ -3,6 +3,7 @@ namespace phpbu\App\Backup\Sync;
 
 use phpbu\App\Backup\CliMockery;
 use phpbu\App\BaseMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * RsyncTest
@@ -15,7 +16,7 @@ use phpbu\App\BaseMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class RsyncTest extends \PHPUnit\Framework\TestCase
+class RsyncTest extends TestCase
 {
     use BaseMockery;
     use CliMockery;

--- a/tests/phpbu/Backup/Sync/SoftLayerTest.php
+++ b/tests/phpbu/Backup/Sync/SoftLayerTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Sync;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * SoftLayerTest
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Sync;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.6
  */
-class SoftLayerTest extends \PHPUnit\Framework\TestCase
+class SoftLayerTest extends TestCase
 {
     /**
      * Tests SoftLayer::setUp

--- a/tests/phpbu/Backup/Target/CompressionTest.php
+++ b/tests/phpbu/Backup/Target/CompressionTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Backup\Target;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Compressor test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Backup\Target;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class CompressionTest extends \PHPUnit\Framework\TestCase
+class CompressionTest extends TestCase
 {
     /**
      * Tests Compression::create

--- a/tests/phpbu/Backup/TargetTest.php
+++ b/tests/phpbu/Backup/TargetTest.php
@@ -28,7 +28,7 @@ class TargetTest extends TestCase
         $target   = new Target($path, $filename);
         $target->setupPath();
 
-        $this->assertTrue(is_dir($target->getPath()->getPath()));
+        $this->assertDirectoryExists($target->getPath()->getPath());
 
         rmdir($target->getPath()->getPath());
     }
@@ -437,7 +437,7 @@ class TargetTest extends TestCase
         $filename = basename(__FILE__);
         $target   = new Target($path, $filename, strtotime('2014-12-01 04:30:57'));
 
-        $this->assertEquals(true, $target->fileExists());
+        $this->assertTrue($target->fileExists());
     }
 
     /**

--- a/tests/phpbu/Cli/Executable/ArangodumpTest.php
+++ b/tests/phpbu/Cli/Executable/ArangodumpTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * ArangodumpTest
  *
@@ -13,7 +15,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class ArangodumpTest extends \PHPUnit\Framework\TestCase
+class ArangodumpTest extends TestCase
 {
     /**
      * Tests Arangodump::createCommand

--- a/tests/phpbu/Cli/Executable/CompressorTest.php
+++ b/tests/phpbu/Cli/Executable/CompressorTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Compressor Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class CompressorTest extends \PHPUnit\Framework\TestCase
+class CompressorTest extends TestCase
 {
     /**
      * Tests Compressor::getCommand

--- a/tests/phpbu/Cli/Executable/ElasticdumpTest.php
+++ b/tests/phpbu/Cli/Executable/ElasticdumpTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Elasticdump Executable Test
  *
@@ -13,7 +15,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class ElasticdumpTest extends \PHPUnit\Framework\TestCase
+class ElasticdumpTest extends TestCase
 {
     /**
      * Tests Elasticdump::createCommandLine

--- a/tests/phpbu/Cli/Executable/InfluxdumpTest.php
+++ b/tests/phpbu/Cli/Executable/InfluxdumpTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * InfluxdumpTest ExecutableTest
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.12
  */
-class InfluxdumpTest extends \PHPUnit\Framework\TestCase
+class InfluxdumpTest extends TestCase
 {
     /**
      * Tests Influxdump::getCommand

--- a/tests/phpbu/Cli/Executable/InnobackupexTest.php
+++ b/tests/phpbu/Cli/Executable/InnobackupexTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * XtraBackup Executable Test
  *
@@ -13,7 +15,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class InnobackupexTest extends \PHPUnit\Framework\TestCase
+class InnobackupexTest extends TestCase
 {
     /**
      * Tests XtraBackup::createCommandLine

--- a/tests/phpbu/Cli/Executable/LdapdumpTest.php
+++ b/tests/phpbu/Cli/Executable/LdapdumpTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Cli\Executable;
 
 use phpbu\App\Backup\Target\Compression;
+use PHPUnit\Framework\TestCase;
 
 /**
  * LdapdumpTest ExecutableTest
@@ -15,7 +16,7 @@ use phpbu\App\Backup\Target\Compression;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.12
  */
-class LdapdumpTest extends \PHPUnit\Framework\TestCase
+class LdapdumpTest extends TestCase
 {
     /**
      * Tests Ldapdump::getCommand

--- a/tests/phpbu/Cli/Executable/McryptTest.php
+++ b/tests/phpbu/Cli/Executable/McryptTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Mcrypt ExecutableTest
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class McryptTest extends \PHPUnit\Framework\TestCase
+class McryptTest extends TestCase
 {
     /**
      * Tests Mcrypt::createCommandLine

--- a/tests/phpbu/Cli/Executable/MongodumpTest.php
+++ b/tests/phpbu/Cli/Executable/MongodumpTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Mongodump Executable Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class MongodumpTest extends \PHPUnit\Framework\TestCase
+class MongodumpTest extends TestCase
 {
     /**
      * Tests Mongodump::createCommandLine
@@ -129,7 +131,7 @@ class MongodumpTest extends \PHPUnit\Framework\TestCase
     public function testExcludeCollections()
     {
         $mongo = new Mongodump(PHPBU_TEST_BIN);
-        $mongo->dumpToDirectory('./dump')->excludeCollections(array('col1', 'col2'));
+        $mongo->dumpToDirectory('./dump')->excludeCollections(['col1', 'col2']);
 
         $this->assertEquals(
             PHPBU_TEST_BIN . '/mongodump --out \'./dump' . '\' --excludeCollection \'col1\' \'col2\'',
@@ -143,7 +145,7 @@ class MongodumpTest extends \PHPUnit\Framework\TestCase
     public function testExcludeCollectionsWithPrefix()
     {
         $mongo = new Mongodump(PHPBU_TEST_BIN);
-        $mongo->dumpToDirectory('./dump')->excludeCollectionsWithPrefix(array('pre1', 'pre2'));
+        $mongo->dumpToDirectory('./dump')->excludeCollectionsWithPrefix(['pre1', 'pre2']);
 
         $this->assertEquals(
             PHPBU_TEST_BIN . '/mongodump --out \'./dump' . '\' --excludeCollectionWithPrefix \'pre1\' \'pre2\'',

--- a/tests/phpbu/Cli/Executable/MysqlTest.php
+++ b/tests/phpbu/Cli/Executable/MysqlTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Mysql Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 6.0-dev
  */
-class MysqlTest extends \PHPUnit\Framework\TestCase
+class MysqlTest extends TestCase
 {
     /**
      * Tests Mysql::getCommand

--- a/tests/phpbu/Cli/Executable/MysqlimportTest.php
+++ b/tests/phpbu/Cli/Executable/MysqlimportTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Cli\Executable;
 
 use phpbu\App\Exception;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Mysqlimport Test
@@ -14,7 +15,7 @@ use phpbu\App\Exception;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 6.0-dev
  */
-class MysqlimportTest extends \PHPUnit\Framework\TestCase
+class MysqlimportTest extends TestCase
 {
     /**
      * Tests Mysqlimport::getCommand

--- a/tests/phpbu/Cli/Executable/PgdumpTest.php
+++ b/tests/phpbu/Cli/Executable/PgdumpTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Pgdump Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 3.0.0
  */
-class PgdumpTest extends \PHPUnit\Framework\TestCase
+class PgdumpTest extends TestCase
 {
     /**
      * Tests Pgdump::getCommand

--- a/tests/phpbu/Cli/Executable/RedisCliTest.php
+++ b/tests/phpbu/Cli/Executable/RedisCliTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * RedisCli ExecutableTest
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.12
  */
-class RedisCliTest extends \PHPUnit\Framework\TestCase
+class RedisCliTest extends TestCase
 {
     /**
      * Tests RedisCli::getProcess

--- a/tests/phpbu/Cli/Executable/Rsync/LocationTest.php
+++ b/tests/phpbu/Cli/Executable/Rsync/LocationTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable\Rsync;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Rsync Location Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable\Rsync;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 3.1.4
  */
-class LocationTest extends \PHPUnit\Framework\TestCase
+class LocationTest extends TestCase
 {
     /**
      * Tests Rsync::toString

--- a/tests/phpbu/Cli/Executable/RsyncTest.php
+++ b/tests/phpbu/Cli/Executable/RsyncTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Rsync Executable Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class RsyncTest extends \PHPUnit\Framework\TestCase
+class RsyncTest extends TestCase
 {
     /**
      * Tests Rsync::getCommandLine

--- a/tests/phpbu/Cli/Executable/TarTest.php
+++ b/tests/phpbu/Cli/Executable/TarTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli\Executable;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tar Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli\Executable;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.1.0
  */
-class TarTest extends \PHPUnit\Framework\TestCase
+class TarTest extends TestCase
 {
     /**
      * Tests Tar::getCommandLine

--- a/tests/phpbu/Cli/ResultTest.php
+++ b/tests/phpbu/Cli/ResultTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Cli;
 
 use SebastianFeldmann\Cli\Command\Result as CommandResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ResultTest
@@ -15,7 +16,7 @@ use SebastianFeldmann\Cli\Command\Result as CommandResult;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class ResultTest extends \PHPUnit\Framework\TestCase
+class ResultTest extends TestCase
 {
     /**
      * Tests Result::getCmdResult

--- a/tests/phpbu/Cli/StatisticsTest.php
+++ b/tests/phpbu/Cli/StatisticsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cli;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * StatisticsTest
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cli;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.2
  */
-class StatisticsTest extends \PHPUnit\Framework\TestCase
+class StatisticsTest extends TestCase
 {
     /**
      * Tests Statistics::resourceUsage
@@ -21,7 +23,7 @@ class StatisticsTest extends \PHPUnit\Framework\TestCase
     {
         $usage = Statistics::resourceUsage();
 
-        $this->assertTrue(strpos($usage, 'Time:') !== false);
-        $this->assertTrue(strpos($usage, 'Memory:') !== false);
+        $this->assertStringContainsString('Time:', $usage);
+        $this->assertStringContainsString('Memory:', $usage);
     }
 }

--- a/tests/phpbu/Cmd/ArgsTest.php
+++ b/tests/phpbu/Cmd/ArgsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Cmd;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Args parser test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Cmd;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class ArgsTest extends \PHPUnit\Framework\TestCase
+class ArgsTest extends TestCase
 {
     /**
      * Test short option -h

--- a/tests/phpbu/Configuration/Backup/TargetTest.php
+++ b/tests/phpbu/Configuration/Backup/TargetTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Configuration\Backup;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Target Configuration test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Configuration\Backup;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class TargetTest extends \PHPUnit\Framework\TestCase
+class TargetTest extends TestCase
 {
     /**
      * Tests Target::__construct()

--- a/tests/phpbu/Configuration/BackupTest.php
+++ b/tests/phpbu/Configuration/BackupTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Configuration;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Backup Configuration test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class BackupTest extends \PHPUnit\Framework\TestCase
+class BackupTest extends TestCase
 {
     /**
      * Tests Backup::__construct()
@@ -22,8 +24,8 @@ class BackupTest extends \PHPUnit\Framework\TestCase
         $backup = new Backup('name', false);
 
         $this->assertEquals('name', $backup->getName());
-        $this->assertTrue(is_array($backup->getChecks()));
-        $this->assertTrue(is_array($backup->getSyncs()));
+        $this->assertIsArray($backup->getChecks());
+        $this->assertIsArray($backup->getSyncs());
     }
 
     /**
@@ -34,9 +36,9 @@ class BackupTest extends \PHPUnit\Framework\TestCase
         $backup = new Backup('name', false);
         $check  = new Backup\Check('SizeMin', '10M');
 
-        $this->assertEquals(0, count($backup->getChecks()));
+        $this->assertCount(0, $backup->getChecks());
         $backup->addCheck($check);
-        $this->assertEquals(1, count($backup->getChecks()));
+        $this->assertCount(1, $backup->getChecks());
     }
 
     /**
@@ -77,9 +79,9 @@ class BackupTest extends \PHPUnit\Framework\TestCase
         $backup = new Backup('name', false);
         $sync   = new Backup\Sync('dropbox', true);
 
-        $this->assertEquals(0, count($backup->getSyncs()));
+        $this->assertCount(0, $backup->getSyncs());
         $backup->addSync($sync);
-        $this->assertEquals(1, count($backup->getSyncs()));
+        $this->assertCount(1, $backup->getSyncs());
     }
 
     /**

--- a/tests/phpbu/Configuration/BootstrapperTest.php
+++ b/tests/phpbu/Configuration/BootstrapperTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Configuration;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Bootstrap Runner test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 3.0.0
  */
-class BootstrapperTest extends \PHPUnit\Framework\TestCase
+class BootstrapperTest extends TestCase
 {
     /**
      * Tests Bootstrapper::run

--- a/tests/phpbu/Configuration/FinderTest.php
+++ b/tests/phpbu/Configuration/FinderTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Configuration;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Finder test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class FinderTest extends \PHPUnit\Framework\TestCase
+class FinderTest extends TestCase
 {
     /**
      * Tests Finder::findConfiguration

--- a/tests/phpbu/Configuration/Loader/FactoryTest.php
+++ b/tests/phpbu/Configuration/Loader/FactoryTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Configuration\Loader;
 
 use phpbu\App\Configuration\Bootstrapper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Loader Factory test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration\Bootstrapper;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 3.0.0
  */
-class FactoryTest extends \PHPUnit\Framework\TestCase
+class FactoryTest extends TestCase
 {
     /**
      * Tests Factory::createLoader
@@ -24,7 +25,7 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $file   = PHPBU_TEST_FILES . '/conf/json/config-valid.json';
         $loader = Factory::createLoader($file, new Bootstrapper());
 
-        $this->assertTrue($loader instanceof Json);
+        $this->assertInstanceOf(Json::class, $loader);
     }
 
     /**
@@ -35,6 +36,6 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $file   = PHPBU_TEST_FILES . '/conf/json/config-valid.json';
         $loader = Factory::createLoader($file);
 
-        $this->assertTrue($loader instanceof Json);
+        $this->assertInstanceOf(Json::class, $loader);
     }
 }

--- a/tests/phpbu/Configuration/Loader/JsonTest.php
+++ b/tests/phpbu/Configuration/Loader/JsonTest.php
@@ -150,8 +150,8 @@ class JsonTest extends TestCase
         $config = $loader->getConfiguration(self::$factory);
 
         $this->assertEquals($dir . '/backup/bootstrap.php', $config->getBootstrap());
-        $this->assertEquals(true, $config->getColors());
-        $this->assertEquals(false, $config->getVerbose());
+        $this->assertTrue($config->getColors());
+        $this->assertFalse($config->getVerbose());
     }
 
     /**
@@ -170,10 +170,10 @@ class JsonTest extends TestCase
         $crypt    = $backup->getCrypt();
         $cleanup  = $backup->getCleanup();
 
-        $this->assertTrue(is_array($backups));
-        $this->assertEquals(1, count($backups), 'should be exactly one backup');
+        $this->assertIsArray($backups);
+        $this->assertCount(1, $backups, 'should be exactly one backup');
         $this->assertEquals('tarball', $backup->getName());
-        $this->assertEquals(false, $backup->stopOnFailure());
+        $this->assertFalse($backup->stopOnFailure());
         $this->assertEquals('tar', $backup->getSource()->type);
         $this->assertEquals($dir . '/backup/src', $backup->getTarget()->dirname);
         $this->assertEquals('tarball-%Y%m%d-%H%i.tar', $backup->getTarget()->filename);
@@ -196,9 +196,9 @@ class JsonTest extends TestCase
         $backups = $conf->getBackups();
         $backup  = $backups[0];
 
-        $this->assertEquals(1, count($conf->getBackups()), 'should be exactly one backup');
-        $this->assertTrue(is_array($backup->getChecks()));
-        $this->assertEquals(0, count($backup->getChecks()));
+        $this->assertCount(1, $conf->getBackups(), 'should be exactly one backup');
+        $this->assertIsArray($backup->getChecks());
+        $this->assertCount(0, $backup->getChecks());
     }
 
     /**
@@ -213,7 +213,7 @@ class JsonTest extends TestCase
         $loggers = $conf->getLoggers();
         $log1    = $loggers[0];
 
-        $this->assertEquals(2, count($loggers), 'should be exactly two logger');
+        $this->assertCount(2, $loggers, 'should be exactly two logger');
         $this->assertEquals('json', $log1->type);
         $this->assertEquals($dir . '/backup/json.log', $log1->options['target']);
     }
@@ -228,8 +228,8 @@ class JsonTest extends TestCase
         $conf    = $loader->getConfiguration(self::$factory);
         $loggers = $conf->getLoggers();
 
-        $this->assertTrue(is_array($loggers));
-        $this->assertEquals(1, count($loggers), 'should be exactly one logger');
+        $this->assertIsArray($loggers);
+        $this->assertCount(1, $loggers, 'should be exactly one logger');
     }
 
 

--- a/tests/phpbu/Configuration/Loader/XmlTest.php
+++ b/tests/phpbu/Configuration/Loader/XmlTest.php
@@ -159,8 +159,8 @@ class XmlTest extends TestCase
         $this->assertFalse($loader->hasValidationErrors());
         $this->assertCount(0, $loader->getValidationErrors());
         $this->assertEquals($dir . '/backup/bootstrap.php', $config->getBootstrap());
-        $this->assertEquals(true, $config->getColors());
-        $this->assertEquals(false, $config->getVerbose());
+        $this->assertTrue($config->getColors());
+        $this->assertFalse($config->getVerbose());
     }
 
     /**
@@ -179,10 +179,10 @@ class XmlTest extends TestCase
         $crypt   = $backup->getCrypt();
         $cleanup = $backup->getCleanup();
 
-        $this->assertTrue(is_array($backups));
-        $this->assertEquals(1, count($backups), 'should be exactly one backup');
+        $this->assertIsArray($backups);
+        $this->assertCount(1, $backups, 'should be exactly one backup');
         $this->assertEquals('tarball', $backup->getName());
-        $this->assertEquals(false, $backup->stopOnFailure());
+        $this->assertFalse($backup->stopOnFailure());
         $this->assertEquals('tar', $backup->getSource()->type);
         $this->assertEquals($dir . '/backup/src', $backup->getTarget()->dirname);
         $this->assertEquals('tarball-%Y%m%d-%H%i.tar', $backup->getTarget()->filename);
@@ -205,9 +205,9 @@ class XmlTest extends TestCase
         $backups = $conf->getBackups();
         $backup  = $backups[0];
 
-        $this->assertEquals(1, count($conf->getBackups()), 'should be exactly one backup');
-        $this->assertTrue(is_array($backup->getChecks()));
-        $this->assertEquals(0, count($backup->getChecks()));
+        $this->assertCount(1, $conf->getBackups(), 'should be exactly one backup');
+        $this->assertIsArray($backup->getChecks());
+        $this->assertCount(0, $backup->getChecks());
     }
 
     /**
@@ -222,7 +222,7 @@ class XmlTest extends TestCase
         $loggers = $conf->getLoggers();
         $log1    = $loggers[0];
 
-        $this->assertEquals(2, count($loggers), 'should be exactly two logger');
+        $this->assertCount(2, $loggers, 'should be exactly two logger');
         $this->assertEquals('json', $log1->type);
         $this->assertEquals($dir . '/backup/json.log', $log1->options['target']);
     }
@@ -237,8 +237,8 @@ class XmlTest extends TestCase
         $conf    = $loader->getConfiguration(self::$factory);
         $loggers = $conf->getLoggers();
 
-        $this->assertTrue(is_array($loggers));
-        $this->assertEquals(1, count($loggers), 'should be exactly one logger');
+        $this->assertIsArray($loggers);
+        $this->assertCount(1, $loggers, 'should be exactly one logger');
     }
 
     /**

--- a/tests/phpbu/ConfigurationTest.php
+++ b/tests/phpbu/ConfigurationTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Configuration test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class ConfigurationTest extends \PHPUnit\Framework\TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * Tests Configuration::getWorkingDirectory
@@ -39,9 +41,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
-        $this->assertEquals(false, $conf->getVerbose());
+        $this->assertFalse($conf->getVerbose());
         $conf->setVerbose(true);
-        $this->assertEquals(true, $conf->getVerbose());
+        $this->assertTrue($conf->getVerbose());
     }
 
     /**
@@ -51,9 +53,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
-        $this->assertEquals(false, $conf->getColors());
+        $this->assertFalse($conf->getColors());
         $conf->setColors(true);
-        $this->assertEquals(true, $conf->getColors());
+        $this->assertTrue($conf->getColors());
     }
 
     /**
@@ -63,9 +65,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
-        $this->assertEquals(false, $conf->getDebug());
+        $this->assertFalse($conf->getDebug());
         $conf->setDebug(true);
-        $this->assertEquals(true, $conf->getDebug());
+        $this->assertTrue($conf->getDebug());
     }
 
     /**
@@ -75,9 +77,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
-        $this->assertEquals(false, $conf->isRestore());
+        $this->assertFalse($conf->isRestore());
         $conf->setRestore(true);
-        $this->assertEquals(true, $conf->isRestore());
+        $this->assertTrue($conf->isRestore());
     }
 
     /**
@@ -87,9 +89,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
-        $this->assertEquals(false, $conf->isSimulation());
+        $this->assertFalse($conf->isSimulation());
         $conf->setSimulate(true);
-        $this->assertEquals(true, $conf->isSimulation());
+        $this->assertTrue($conf->isSimulation());
     }
 
     /**
@@ -112,9 +114,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $conf = new Configuration();
         $conf->setLimit(['foo', 'bar']);
 
-        $this->assertEquals(true, $conf->isBackupActive('foo'));
-        $this->assertEquals(true, $conf->isBackupActive('bar'));
-        $this->assertEquals(false, $conf->isBackupActive('baz'));
+        $this->assertTrue($conf->isBackupActive('foo'));
+        $this->assertTrue($conf->isBackupActive('bar'));
+        $this->assertFalse($conf->isBackupActive('baz'));
     }
 
     /**
@@ -146,9 +148,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
         $backup = new Configuration\Backup('backup', true);
-        $this->assertEquals(array(), $conf->getBackups());
+        $this->assertEquals([], $conf->getBackups());
         $conf->addBackup($backup);
-        $this->assertEquals(1, count($conf->getBackups()));
+        $this->assertCount(1, $conf->getBackups());
     }
 
     /**
@@ -158,10 +160,10 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
     {
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
-        $logger = new Configuration\Logger('json', array());
-        $this->assertEquals(array(), $conf->getLoggers());
+        $logger = new Configuration\Logger('json', []);
+        $this->assertEquals([], $conf->getLoggers());
         $conf->addLogger($logger);
-        $this->assertEquals(1, count($conf->getLoggers()));
+        $this->assertCount(1, $conf->getLoggers());
     }
 
     /**
@@ -172,9 +174,9 @@ class ConfigurationTest extends \PHPUnit\Framework\TestCase
         $conf = new Configuration();
         $conf->setFilename('/tmp/foo.xml');
         $logger = new Result\PrinterCli(false, false, false);
-        $this->assertEquals(array(), $conf->getLoggers());
+        $this->assertEquals([], $conf->getLoggers());
         $conf->addLogger($logger);
-        $this->assertEquals(1, count($conf->getLoggers()));
+        $this->assertCount(1, $conf->getLoggers());
     }
 
     /**

--- a/tests/phpbu/Event/App/EndTest.php
+++ b/tests/phpbu/Event/App/EndTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Event\App;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * End test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Event\App;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class EndTest extends \PHPUnit\Framework\TestCase
+class EndTest extends TestCase
 {
     /**
      * Tests End::getResult

--- a/tests/phpbu/Event/App/StartTest.php
+++ b/tests/phpbu/Event/App/StartTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Event\App;
 
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Start test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class StartTest extends \PHPUnit\Framework\TestCase
+class StartTest extends TestCase
 {
     /**
      * Tests Start::getConfig
@@ -27,6 +28,6 @@ class StartTest extends \PHPUnit\Framework\TestCase
         $start  = new Start($conf);
         $config = $start->getConfiguration();
 
-        $this->assertEquals(true, $config->getDebug());
+        $this->assertTrue($config->getDebug());
     }
 }

--- a/tests/phpbu/Event/Backup/StartTest.php
+++ b/tests/phpbu/Event/Backup/StartTest.php
@@ -4,6 +4,7 @@ namespace phpbu\App\Event\Backup;
 use phpbu\App\Backup\Source\FakeSource;
 use phpbu\App\Backup\Target;
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Backup Start test
@@ -16,7 +17,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class StartTest extends \PHPUnit\Framework\TestCase
+class StartTest extends TestCase
 {
     /**
      * Tests Start::getConfiguration

--- a/tests/phpbu/Event/Check/StartTest.php
+++ b/tests/phpbu/Event/Check/StartTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Event\Check;
 
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Check Start test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class StartTest extends \PHPUnit\Framework\TestCase
+class StartTest extends TestCase
 {
     /**
      * Tests Start::getConfiguration

--- a/tests/phpbu/Event/Cleanup/StartTest.php
+++ b/tests/phpbu/Event/Cleanup/StartTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Event\Cleanup;
 
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Cleanup Start test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class StartTest extends \PHPUnit\Framework\TestCase
+class StartTest extends TestCase
 {
     /**
      * Tests Start::getConfiguration

--- a/tests/phpbu/Event/Crypt/StartTest.php
+++ b/tests/phpbu/Event/Crypt/StartTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Event\Crypt;
 
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Crypt Start test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class StartTest extends \PHPUnit\Framework\TestCase
+class StartTest extends TestCase
 {
     /**
      * Tests Start::getConfiguration

--- a/tests/phpbu/Event/DebugTest.php
+++ b/tests/phpbu/Event/DebugTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Event;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Debug test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Event;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class DebugTest extends \PHPUnit\Framework\TestCase
+class DebugTest extends TestCase
 {
     /**
      * Tests Debug::getMessage

--- a/tests/phpbu/Event/Sync/StartTest.php
+++ b/tests/phpbu/Event/Sync/StartTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Event\Sync;
 
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Sync Start test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 2.0.0
  */
-class StartTest extends \PHPUnit\Framework\TestCase
+class StartTest extends TestCase
 {
     /**
      * Tests Start::getConfiguration

--- a/tests/phpbu/FactoryTest.php
+++ b/tests/phpbu/FactoryTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Factory test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class FactoryTest extends \PHPUnit\Framework\TestCase
+class FactoryTest extends TestCase
 {
     /**
      * Tests Factory::createAdapter
@@ -39,7 +41,7 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('test-file.bz2', $target->getFilename());
         $this->assertEquals($directory . '/test-file.bz2', $target->getPathname());
 
-        $this->assertTrue(file_exists($directory));
+        $this->assertFileExists($directory);
 
         rmdir($directory);
     }

--- a/tests/phpbu/Log/FileTest.php
+++ b/tests/phpbu/Log/FileTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Printer Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Log;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.2.1
  */
-class FileTest extends \PHPUnit\Framework\TestCase
+class FileTest extends TestCase
 {
     /**
      * Tests Printer::setAutoFlush
@@ -64,7 +66,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $file->write('foo');
         $file->close();
 
-        $this->assertTrue(file_exists($log));
+        $this->assertFileExists($log);
 
         unlink($log);
         rmdir(dirname($log));

--- a/tests/phpbu/Log/JsonTest.php
+++ b/tests/phpbu/Log/JsonTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Json Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Log;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 3.0.0
  */
-class JsonTest extends \PHPUnit\Framework\TestCase
+class JsonTest extends TestCase
 {
     /**
      * Tests Json::getSubscribedEvents
@@ -20,7 +22,7 @@ class JsonTest extends \PHPUnit\Framework\TestCase
     public function testSubscribedEvents()
     {
         $events = Json::getSubscribedEvents();
-        $this->assertEquals(2, count($events));
+        $this->assertCount(2, $events);
     }
 
     /**
@@ -61,7 +63,7 @@ class JsonTest extends \PHPUnit\Framework\TestCase
         $outputPHP  = json_decode($outputJson);
 
 
-        $this->assertTrue($outputPHP instanceof \stdClass);
+        $this->assertInstanceOf(\stdClass::class, $outputPHP);
     }
 
     /**

--- a/tests/phpbu/Log/MailTemplateTest.php
+++ b/tests/phpbu/Log/MailTemplateTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Mail Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Log;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class MailTemplateTest extends \PHPUnit\Framework\TestCase
+class MailTemplateTest extends TestCase
 {
     /**
      * Tests MailTemplate::setSnippets
@@ -27,7 +29,7 @@ class MailTemplateTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetSnippets()
     {
-        MailTemplate::setSnippets(array('foo' => 'bar'));
+        MailTemplate::setSnippets(['foo' => 'bar']);
 
         $this->assertEquals('bar', MailTemplate::getSnippet('foo'));
     }

--- a/tests/phpbu/Log/MailTest.php
+++ b/tests/phpbu/Log/MailTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Mail Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Log;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class MailTest extends \PHPUnit\Framework\TestCase
+class MailTest extends TestCase
 {
     /**
      * Tests Mail::getSubscribedEvents
@@ -21,8 +23,8 @@ class MailTest extends \PHPUnit\Framework\TestCase
     {
         $events = Mail::getSubscribedEvents();
 
-        $this->assertTrue(array_key_exists('phpbu.backup_start', $events));
-        $this->assertTrue(array_key_exists('phpbu.check_start', $events));
+        $this->assertArrayHasKey('phpbu.backup_start', $events);
+        $this->assertArrayHasKey('phpbu.check_start', $events);
 
         $this->assertEquals('onPhpbuEnd', $events['phpbu.app_end']);
     }

--- a/tests/phpbu/Log/ResultFormatter/FormDataTest.php
+++ b/tests/phpbu/Log/ResultFormatter/FormDataTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Log\ResultFormatter;
 
 use function GuzzleHttp\Psr7\parse_query;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FormData Formatter Test
@@ -14,7 +15,7 @@ use function GuzzleHttp\Psr7\parse_query;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class FormDataTest extends \PHPUnit\Framework\TestCase
+class FormDataTest extends TestCase
 {
     /**
      * Tests FormData::format
@@ -26,7 +27,7 @@ class FormDataTest extends \PHPUnit\Framework\TestCase
         $queryString = $formatter->format($result);
         $rawData     = parse_query($queryString);
 
-        $this->assertTrue(!empty($queryString));
+        $this->assertNotEmpty($queryString);
         $this->assertEquals(0, $rawData['status']);
         $this->assertEquals(1, $rawData['errorCount']);
     }

--- a/tests/phpbu/Log/ResultFormatter/JsonTest.php
+++ b/tests/phpbu/Log/ResultFormatter/JsonTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Log\ResultFormatter;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Json Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Log\ResultFormatter;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class JsonTest extends \PHPUnit\Framework\TestCase
+class JsonTest extends TestCase
 {
     /**
      * Tests Json::format
@@ -28,8 +30,8 @@ class JsonTest extends \PHPUnit\Framework\TestCase
         $raw = json_decode($json, true);
 
         $this->assertEquals(0, $raw['status']);
-        $this->assertEquals(1, count($raw['errors']));
-        $this->assertEquals(1, count($raw['backups']));
+        $this->assertCount(1, $raw['errors']);
+        $this->assertCount(1, $raw['backups']);
         $this->assertEquals('foo', $raw['backups'][0]['name']);
     }
 

--- a/tests/phpbu/Log/ResultFormatter/TemplateTest.php
+++ b/tests/phpbu/Log/ResultFormatter/TemplateTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Log\ResultFormatter;
 
 use phpbu\App\Exception;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Template Formatter Test
@@ -14,7 +15,7 @@ use phpbu\App\Exception;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class TemplateTestTest extends \PHPUnit\Framework\TestCase
+class TemplateTestTest extends TestCase
 {
     /**
      * Test Template::__construct
@@ -37,9 +38,9 @@ class TemplateTestTest extends \PHPUnit\Framework\TestCase
         $formatter = new Template($path);
         $body      = $formatter->format($result);
 
-        $this->assertTrue(strpos($body, '<return>0</return>') !== false, 'result should exist');
-        $this->assertTrue(strpos($body, '<status>0</status>') !== false, 'status should exist');
-        $this->assertTrue(!strpos($body, '%%'), 'no % should exist anymore');
+        $this->assertStringContainsString('<return>0</return>', $body, 'result should exist');
+        $this->assertStringContainsString('<status>0</status>', $body, 'status should exist');
+        $this->assertStringNotContainsString('%%', $body, 'no % should exist anymore');
     }
 
     /**

--- a/tests/phpbu/Log/ResultFormatter/XmlTest.php
+++ b/tests/phpbu/Log/ResultFormatter/XmlTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Log\ResultFormatter;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Xml Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Log\ResultFormatter;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class XmlTest extends \PHPUnit\Framework\TestCase
+class XmlTest extends TestCase
 {
     /**
      * Tests Xml::format
@@ -23,11 +25,11 @@ class XmlTest extends \PHPUnit\Framework\TestCase
         $formatter = new Xml();
         $xml       = $formatter->format($result);
 
-        $this->assertTrue(!empty($xml));
+        $this->assertNotEmpty($xml);
 
         $simpleXml = simplexml_load_string($xml);
 
-        $this->assertTrue($simpleXml instanceof \SimpleXMLElement);
+        $this->assertInstanceOf(\SimpleXMLElement::class, $simpleXml);
     }
 
     /**

--- a/tests/phpbu/Log/TelegramTest.php
+++ b/tests/phpbu/Log/TelegramTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Log;
 
 use phpbu\App\Result;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Telegram Test
@@ -15,7 +16,7 @@ use phpbu\App\Result;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class TelegramTest extends \PHPUnit\Framework\TestCase
+class TelegramTest extends TestCase
 {
     public function testSetUpOk()
     {
@@ -82,7 +83,7 @@ class TelegramTest extends \PHPUnit\Framework\TestCase
     {
         $events = Telegram::getSubscribedEvents();
 
-        $this->assertTrue(array_key_exists('phpbu.app_end', $events));
+        $this->assertArrayHasKey('phpbu.app_end', $events);
         $this->assertEquals('onPhpbuEnd', $events['phpbu.app_end']);
     }
 

--- a/tests/phpbu/Log/WebhookTest.php
+++ b/tests/phpbu/Log/WebhookTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Log;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Webhook Test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Log;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.0.0
  */
-class WebhookTest extends \PHPUnit\Framework\TestCase
+class WebhookTest extends TestCase
 {
     /**
      * Tests Webhook::getSubscribedEvents
@@ -20,7 +22,7 @@ class WebhookTest extends \PHPUnit\Framework\TestCase
     public function testSubscribedEvents()
     {
         $events = Webhook::getSubscribedEvents();
-        $this->assertEquals(1, count($events));
+        $this->assertCount(1, $events);
     }
 
     /**

--- a/tests/phpbu/Result/BackupTest.php
+++ b/tests/phpbu/Result/BackupTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Result;
 
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Backup test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.6
  */
-class BackupTest extends \PHPUnit\Framework\TestCase
+class BackupTest extends TestCase
 {
     /**
      * Tests Backup::wasSuccessFul

--- a/tests/phpbu/Result/PrinterCliTest.php
+++ b/tests/phpbu/Result/PrinterCliTest.php
@@ -2,6 +2,7 @@
 namespace phpbu\App\Result;
 
 use phpbu\App\Configuration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PrinterCli test
@@ -14,7 +15,7 @@ use phpbu\App\Configuration;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.6
  */
-class PrinterCliTest extends \PHPUnit\Framework\TestCase
+class PrinterCliTest extends TestCase
 {
     /**
      * Tests Mail::getSubscribedEvents
@@ -23,9 +24,9 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     {
         $events = PrinterCli::getSubscribedEvents();
 
-        $this->assertTrue(array_key_exists('phpbu.debug', $events));
-        $this->assertTrue(array_key_exists('phpbu.backup_start', $events));
-        $this->assertTrue(array_key_exists('phpbu.check_start', $events));
+        $this->assertArrayHasKey('phpbu.debug', $events);
+        $this->assertArrayHasKey('phpbu.backup_start', $events);
+        $this->assertArrayHasKey('phpbu.check_start', $events);
 
         $this->assertEquals('onPhpbuEnd', $events['phpbu.app_end']);
     }
@@ -37,7 +38,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
     {
         $printer = new PrinterCli(false, false, false);
 
-        $this->assertTrue(!is_null($printer));
+        $this->assertNotNull($printer);
     }
 
     /**
@@ -77,7 +78,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $printer->onPhpbuStart($this->getEventMock('App\\Start', $configuration));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'Runtime') !== false);
+        $this->assertStringContainsString('Runtime', $output);
     }
 
     /**
@@ -113,7 +114,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onBackupStart($this->getEventMock('Backup\\Start', $backup));
         $printer->onBackupEnd($this->getEventMock('Backup\\End', $backup));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'backup') !== false);
+        $this->assertStringContainsString('backup', $output);
     }
 
     /**
@@ -131,7 +132,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onBackupStart($this->getEventMock('Backup\\Start', $backup));
         $printer->onBackupFailed($this->getEventMock('Backup\\Failed', $backup));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'failed') !== false);
+        $this->assertStringContainsString('failed', $output);
     }
 
     /**
@@ -161,7 +162,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCheckStart($this->getEventMock('Check\\Start', $check));
         $printer->onCheckEnd($this->getEventMock('Check\\End', $check));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'check') !== false);
+        $this->assertStringContainsString('check', $output);
     }
 
     /**
@@ -176,7 +177,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCheckStart($this->getEventMock('Check\\Start', $check));
         $printer->onCheckFailed($this->getEventMock('Check\\Failed', $check));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'failed') !== false);
+        $this->assertStringContainsString('failed', $output);
     }
 
 
@@ -207,8 +208,8 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCryptStart($this->getEventMock('Crypt\\Start', $crypt));
         $printer->onCryptEnd($this->getEventMock('Crypt\\End', $crypt));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'crypt') !== false);
-        $this->assertTrue(strpos($output, 'ok') !== false);
+        $this->assertStringContainsString('crypt', $output);
+        $this->assertStringContainsString('ok', $output);
     }
 
     /**
@@ -223,7 +224,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCryptStart($this->getEventMock('Crypt\\Start', $crypt));
         $printer->onCryptFailed($this->getEventMock('Crypt\\Failed', $crypt));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'failed') !== false);
+        $this->assertStringContainsString('failed', $output);
     }
 
     /**
@@ -238,7 +239,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCryptStart($this->getEventMock('Crypt\\Start', $crypt));
         $printer->onCryptSkipped($this->getEventMock('Crypt\\Skipped', $crypt));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'skipped') !== false);
+        $this->assertStringContainsString('skipped', $output);
     }
 
     /**
@@ -268,7 +269,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onSyncStart($this->getEventMock('Sync\\Start', $sync));
         $printer->onSyncEnd($this->getEventMock('Sync\\End', $sync));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'sync') !== false);
+        $this->assertStringContainsString('sync', $output);
     }
 
     /**
@@ -283,7 +284,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onSyncStart($this->getEventMock('Sync\\Start', $sync));
         $printer->onSyncFailed($this->getEventMock('Sync\\Failed', $sync));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'failed') !== false);
+        $this->assertStringContainsString('failed', $output);
     }
 
     /**
@@ -298,7 +299,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onSyncStart($this->getEventMock('Sync\\Start', $sync));
         $printer->onSyncSkipped($this->getEventMock('Sync\\Skipped', $sync));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'skipped') !== false);
+        $this->assertStringContainsString('skipped', $output);
     }
 
     /**
@@ -328,7 +329,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCleanupStart($this->getEventMock('Cleanup\\Start', $cleanup));
         $printer->onCleanupEnd($this->getEventMock('Cleanup\\End', $cleanup));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'cleanup') !== false);
+        $this->assertStringContainsString('cleanup', $output);
     }
 
     /**
@@ -343,7 +344,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCleanupStart($this->getEventMock('Cleanup\\Start', $cleanup));
         $printer->onCleanupFailed($this->getEventMock('Cleanup\\Failed', $cleanup));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'failed') !== false);
+        $this->assertStringContainsString('failed', $output);
     }
 
     /**
@@ -358,7 +359,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer->onCleanupStart($this->getEventMock('Cleanup\\Start', $cleanup));
         $printer->onCleanupSkipped($this->getEventMock('Cleanup\\Skipped', $cleanup));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'skipped') !== false);
+        $this->assertStringContainsString('skipped', $output);
     }
 
     /**
@@ -371,7 +372,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $printer->onDebug($this->getEventMock('Debug', 'foo'));
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'foo') !== false);
+        $this->assertStringContainsString('foo', $output);
     }
 
     /**
@@ -382,8 +383,8 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer = new PrinterCli(true, false, false);
         $result  = $this->createMock(\phpbu\App\Result::class);
         $backup  = $this->createMock(\phpbu\App\Result\Backup::class);
-        $result->method('getBackups')->willReturn(array($backup));
-        $result->method('getErrors')->willReturn(array());
+        $result->method('getBackups')->willReturn([$backup]);
+        $result->method('getErrors')->willReturn([]);
         $result->method('allOk')->willReturn(true);
 
         $backup->method('allOk')->willReturn(true);
@@ -399,7 +400,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $printer->printResult($result);
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'OK') !== false);
+        $this->assertStringContainsString('OK', $output);
     }
 
     /**
@@ -410,13 +411,13 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $printer = new PrinterCli(false, true, false);
         $result  = $this->createMock(\phpbu\App\Result::class);
 
-        $result->method('getBackups')->willReturn(array());
-        $result->method('getErrors')->willReturn(array());
+        $result->method('getBackups')->willReturn([]);
+        $result->method('getErrors')->willReturn([]);
 
         ob_start();
         $printer->printResult($result);
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'No backups executed') !== false);
+        $this->assertStringContainsString('No backups executed', $output);
     }
 
     /**
@@ -441,8 +442,8 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $backup->method('cleanupSkipped')->willReturn(0);
         $backup->method('cleanupCountFailed')->willReturn(0);
 
-        $result->method('getBackups')->willReturn(array($backup));
-        $result->method('getErrors')->willReturn(array());
+        $result->method('getBackups')->willReturn([$backup]);
+        $result->method('getErrors')->willReturn([]);
         $result->method('allOk')->willReturn(false);
         $result->method('wasSuccessful')->willReturn(true);
         $result->method('backupOkButSkipsOrFails')->willReturn(true);
@@ -450,7 +451,7 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $printer->printResult($result);
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'skipped') !== false);
+        $this->assertStringContainsString('skipped', $output);
     }
 
     /**
@@ -475,15 +476,15 @@ class PrinterCliTest extends \PHPUnit\Framework\TestCase
         $backup->method('cleanupSkipped')->willReturn(0);
         $backup->method('cleanupCountFailed')->willReturn(0);
 
-        $result->method('getBackups')->willReturn(array($backup));
-        $result->method('getErrors')->willReturn(array($e));
+        $result->method('getBackups')->willReturn([$backup]);
+        $result->method('getErrors')->willReturn([$e]);
         $result->method('allOk')->willReturn(false);
         $result->method('wasSuccessful')->willReturn(false);
 
         ob_start();
         $printer->printResult($result);
         $output = ob_get_clean();
-        $this->assertTrue(strpos($output, 'FAILURE') !== false);
+        $this->assertStringContainsString('FAILURE', $output);
     }
 
     /**

--- a/tests/phpbu/ResultTest.php
+++ b/tests/phpbu/ResultTest.php
@@ -4,6 +4,7 @@ namespace phpbu\App;
 use phpbu\App\Backup\Check\Exception;
 use phpbu\App\Backup\Source\FakeSource;
 use phpbu\App\Backup\Target;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Version test
@@ -16,7 +17,7 @@ use phpbu\App\Backup\Target;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.6
  */
-class ResultTest extends \PHPUnit\Framework\TestCase
+class ResultTest extends TestCase
 {
     /**
      * Tests Result::wasSuccessFul
@@ -40,7 +41,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $result     = new Result();
         $cliPrinter = new Result\PrinterCli();
         $result->addListener($cliPrinter);
-        $this->assertTrue(is_float($result->started()));
+        $this->assertIsFloat($result->started());
     }
 
     /**
@@ -100,8 +101,8 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0, $result->cleanupsFailedCount());
         $this->assertEquals(0, $result->cleanupsSkippedCount());
         $this->assertEquals(0, $result->errorCount());
-        $this->assertEquals(0, count($result->getErrors()));
-        $this->assertEquals(1, count($result->getBackups()));
+        $this->assertCount(0, $result->getErrors());
+        $this->assertCount(1, $result->getBackups());
     }
 
     /**
@@ -136,8 +137,8 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(0, $result->cleanupsFailedCount());
         $this->assertEquals(1, $result->cleanupsSkippedCount());
         $this->assertEquals(0, $result->errorCount());
-        $this->assertEquals(0, count($result->getErrors()));
-        $this->assertEquals(1, count($result->getBackups()));
+        $this->assertCount(0, $result->getErrors());
+        $this->assertCount(1, $result->getBackups());
     }
 
     /**
@@ -180,8 +181,8 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $result->cleanupsFailedCount());
         $this->assertEquals(0, $result->cleanupsSkippedCount());
         $this->assertEquals(3, $result->errorCount());
-        $this->assertEquals(3, count($result->getErrors()));
-        $this->assertEquals(1, count($result->getBackups()));
+        $this->assertCount(3, $result->getErrors());
+        $this->assertCount(1, $result->getBackups());
     }
 
     /**
@@ -205,8 +206,8 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result->allOk(), 'should be ok');
         $this->assertEquals(1, $result->backupsFailedCount());
         $this->assertEquals(1, $result->errorCount());
-        $this->assertEquals(1, count($result->getErrors()));
-        $this->assertEquals(1, count($result->getBackups()));
+        $this->assertCount(1, $result->getErrors());
+        $this->assertCount(1, $result->getBackups());
     }
 
     /**
@@ -234,8 +235,8 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $result->backupsFailedCount());
         $this->assertEquals(1, $result->checksFailedCount());
         $this->assertEquals(1, $result->errorCount());
-        $this->assertEquals(1, count($result->getErrors()));
-        $this->assertEquals(1, count($result->getBackups()));
+        $this->assertCount(1, $result->getErrors());
+        $this->assertCount(1, $result->getBackups());
     }
 
     /**

--- a/tests/phpbu/Runner/BackupTest.php
+++ b/tests/phpbu/Runner/BackupTest.php
@@ -4,6 +4,7 @@ namespace phpbu\App\Runner;
 use phpbu\App\BaseMockery;
 use phpbu\App\Result;
 use phpbu\App\Runner\Mockery as RunnerMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Backup Test
@@ -16,7 +17,7 @@ use phpbu\App\Runner\Mockery as RunnerMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 3.1.0
  */
-class BackupTest extends \PHPUnit\Framework\TestCase
+class BackupTest extends TestCase
 {
     use BaseMockery;
     use RunnerMockery;

--- a/tests/phpbu/Runner/SimulateTest.php
+++ b/tests/phpbu/Runner/SimulateTest.php
@@ -4,6 +4,7 @@ namespace phpbu\App\Runner;
 use phpbu\App\BaseMockery;
 use phpbu\App\Result;
 use phpbu\App\Runner\Mockery as RunnerMockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Simulate Test
@@ -16,7 +17,7 @@ use phpbu\App\Runner\Mockery as RunnerMockery;
  * @link       https://www.phpbu.de/
  * @since      Class available since Release 3.1.0
  */
-class SimulateTest extends \PHPUnit\Framework\TestCase
+class SimulateTest extends TestCase
 {
     use BaseMockery;
     use RunnerMockery;

--- a/tests/phpbu/Util/ArrTest.php
+++ b/tests/phpbu/Util/ArrTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Util;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Array utility test
  *
@@ -12,14 +14,14 @@ namespace phpbu\App\Util;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.5
  */
-class ArrTest extends \PHPUnit\Framework\TestCase
+class ArrTest extends TestCase
 {
     /**
      * Test isSetAndNotEmptyString
      */
     public function testIsSetAndNotEmptyString()
     {
-        $arr = array('foo' => 'bar', 'baz' => '', 'fiz' => 0);
+        $arr = ['foo' => 'bar', 'baz' => '', 'fiz' => 0];
 
         $this->assertTrue(Arr::isSetAndNotEmptyString($arr, 'foo'), 'foo should be set and not the empty string');
         $this->assertFalse(Arr::isSetAndNotEmptyString($arr, 'baz'), 'baz should be set but the empty string');
@@ -31,10 +33,10 @@ class ArrTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetValue()
     {
-        $arr = array('foo' => 'bar', 'baz' => '', 'fiz' => 0);
+        $arr = ['foo' => 'bar', 'baz' => '', 'fiz' => 0];
 
         $this->assertEquals('bar', Arr::getValue($arr, 'foo'), 'foo should be bar');
-        $this->assertEquals(null, Arr::getValue($arr, 'buz'), 'buz should be null');
+        $this->assertNull(Arr::getValue($arr, 'buz'), 'buz should be null');
         $this->assertEquals(0, Arr::getValue($arr, 'fiz'), 'fiz should be 0');
     }
 
@@ -43,7 +45,7 @@ class ArrTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetValueDefault()
     {
-        $arr = array('foo' => 'bar', 'baz' => '', 'fiz' => 0);
+        $arr = ['foo' => 'bar', 'baz' => '', 'fiz' => 0];
 
         $this->assertEquals('bar', Arr::getValue($arr, 'foo', 'default'), 'foo should be bar');
         $this->assertEquals('default', Arr::getValue($arr, 'buz', 'default'), 'default should be step in');

--- a/tests/phpbu/Util/CliTest.php
+++ b/tests/phpbu/Util/CliTest.php
@@ -34,7 +34,7 @@ class CliTest extends TestCase
     /**
      * Restore $_SERVER settings.
      */
-    public function tearDown() : void
+    protected function tearDown() : void
     {
         $_SERVER = self::$server;
     }
@@ -129,7 +129,7 @@ class CliTest extends TestCase
         $plainText   = 'Mein Test';
         $coloredText = Cli::formatWithColor('fg-black, bg-green', $plainText);
 
-        $this->assertTrue(strpos($coloredText, "\x1b[0m") !== false);
+        $this->assertStringContainsString("\x1b[0m", $coloredText);
     }
 
     /**
@@ -140,7 +140,7 @@ class CliTest extends TestCase
         $plainText   = '';
         $coloredText = Cli::formatWithColor('fg-black, bg-green', $plainText);
 
-        $this->assertTrue(strpos($coloredText, "\x1b[0m") === false);
+        $this->assertStringNotContainsString("\x1b[0m", $coloredText);
     }
 
     /**
@@ -152,7 +152,7 @@ class CliTest extends TestCase
         $decoratedText = Cli::formatWithAsterisk($plainText);
 
         $this->assertEquals(75, strlen(trim($decoratedText)));
-        $this->assertTrue(strpos($decoratedText, '*') !== false);
+        $this->assertStringContainsString('*', $decoratedText);
     }
 
     /**
@@ -181,10 +181,10 @@ class CliTest extends TestCase
 
         Cli::removeDir($dirToDelete);
 
-        $this->assertFalse(file_exists($file));
-        $this->assertFalse(file_exists($fileInSub));
-        $this->assertFalse(file_exists($subDir));
-        $this->assertFalse(file_exists($dirToDelete));
+        $this->assertFileNotExists($file);
+        $this->assertFileNotExists($fileInSub);
+        $this->assertFileNotExists($subDir);
+        $this->assertFileNotExists($dirToDelete);
     }
 
     /**
@@ -193,10 +193,10 @@ class CliTest extends TestCase
     public function testCommandLocationsDefault()
     {
         $list = Cli::getCommandLocations('tar');
-        $this->assertEquals(0, count($list));
+        $this->assertCount(0, $list);
 
         $list = Cli::getCommandLocations('mysqldump');
-        $this->assertEquals(2, count($list));
+        $this->assertCount(2, $list);
     }
 
     /**
@@ -207,7 +207,7 @@ class CliTest extends TestCase
         Cli::addCommandLocation('mongodump', '/foo/mongodump');
         $list = Cli::getCommandLocations('mongodump');
 
-        $this->assertEquals(1, count($list));
+        $this->assertCount(1, $list);
         $this->assertEquals('/foo/mongodump', $list[0]);
     }
 

--- a/tests/phpbu/Util/MathTest.php
+++ b/tests/phpbu/Util/MathTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Util;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Math utility test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Util;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class MathTest extends \PHPUnit\Framework\TestCase
+class MathTest extends TestCase
 {
     /**
      * @dataProvider providerPercentValues
@@ -38,12 +40,12 @@ class MathTest extends \PHPUnit\Framework\TestCase
      */
     public function providerPercentValues()
     {
-        return array(
-            array(100, 90, 10),
-            array(100, 80, 20),
-            array(100, 50, 50),
-            array(80, 100, 20),
-            array(60, 100, 40),
-        );
+        return [
+            [100, 90, 10],
+            [100, 80, 20],
+            [100, 50, 50],
+            [80, 100, 20],
+            [60, 100, 40],
+        ];
     }
 }

--- a/tests/phpbu/Util/PathTest.php
+++ b/tests/phpbu/Util/PathTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Util;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * String utility test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Util;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class PathTest extends \PHPUnit\Framework\TestCase
+class PathTest extends TestCase
 {
     /**
      * @var integer
@@ -116,9 +118,9 @@ class PathTest extends \PHPUnit\Framework\TestCase
      */
     public function testHasTrailingSlash()
     {
-        $this->assertEquals(false, Path::hasTrailingSlash('foo'));
-        $this->assertEquals(false, Path::hasTrailingSlash('/foo/bar'));
-        $this->assertEquals(true, Path::hasTrailingSlash('baz/'));
+        $this->assertFalse(Path::hasTrailingSlash('foo'));
+        $this->assertFalse(Path::hasTrailingSlash('/foo/bar'));
+        $this->assertTrue(Path::hasTrailingSlash('baz/'));
     }
 
     /**
@@ -147,9 +149,9 @@ class PathTest extends \PHPUnit\Framework\TestCase
      */
     public function testHasLeadingSlash()
     {
-        $this->assertEquals(false, Path::hasLeadingSlash('foo'));
-        $this->assertEquals(false, Path::hasLeadingSlash('foo/bar/'));
-        $this->assertEquals(true, Path::hasLeadingSlash('/baz'));
+        $this->assertFalse(Path::hasLeadingSlash('foo'));
+        $this->assertFalse(Path::hasLeadingSlash('foo/bar/'));
+        $this->assertTrue(Path::hasLeadingSlash('/baz'));
     }
 
     /**

--- a/tests/phpbu/Util/StrTest.php
+++ b/tests/phpbu/Util/StrTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Util;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * String utility test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Util;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.0.0
  */
-class StrTest extends \PHPUnit\Framework\TestCase
+class StrTest extends TestCase
 {
     /**
      * @var integer
@@ -111,7 +113,7 @@ class StrTest extends \PHPUnit\Framework\TestCase
     public function testToListFull()
     {
         $list = Str::toList('foo,bar');
-        $this->assertEquals(2, count($list), 'list should contain 2 elements');
+        $this->assertCount(2, $list, 'list should contain 2 elements');
     }
 
     /**
@@ -120,7 +122,7 @@ class StrTest extends \PHPUnit\Framework\TestCase
     public function testToListEmpty()
     {
         $list = Str::toList('');
-        $this->assertEquals(0, count($list), 'list should be empty');
+        $this->assertCount(0, $list, 'list should be empty');
     }
 
     /**
@@ -129,7 +131,7 @@ class StrTest extends \PHPUnit\Framework\TestCase
     public function testToListEmptyTrim()
     {
         $list = Str::toList('foo , bar , baz  ');
-        $this->assertEquals(3, count($list), 'list should be empty');
+        $this->assertCount(3, $list, 'list should be empty');
         $this->assertEquals('foo', $list[0], 'should not contain spaces');
         $this->assertEquals('bar', $list[1], 'should not contain spaces');
         $this->assertEquals('baz', $list[2], 'should noz contain spaces');
@@ -141,7 +143,7 @@ class StrTest extends \PHPUnit\Framework\TestCase
     public function testToListEmptyNoTrim()
     {
         $list = Str::toList('foo  , bar ,  baz', ',', false);
-        $this->assertEquals(3, count($list), 'list should be empty');
+        $this->assertCount(3, $list, 'list should be empty');
         $this->assertEquals('foo  ', $list[0], 'should still contain spaces');
         $this->assertEquals(' bar ', $list[1], 'should still contain spaces');
         $this->assertEquals('  baz', $list[2], 'should still contain spaces');

--- a/tests/phpbu/Util/TimeTest.php
+++ b/tests/phpbu/Util/TimeTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App\Util;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Time utility test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App\Util;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 5.1.2
  */
-class TimeTest extends \PHPUnit\Framework\TestCase
+class TimeTest extends TestCase
 {
     /**
      * Tests Time::timeSinceExecutionStart

--- a/tests/phpbu/VersionTest.php
+++ b/tests/phpbu/VersionTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace phpbu\App;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Version test
  *
@@ -12,7 +14,7 @@ namespace phpbu\App;
  * @link       http://www.phpbu.de/
  * @since      Class available since Release 1.1.6
  */
-class VersionTest extends \PHPUnit\Framework\TestCase
+class VersionTest extends TestCase
 {
     const VERSION = '6.0';
 
@@ -22,10 +24,10 @@ class VersionTest extends \PHPUnit\Framework\TestCase
     public function testId()
     {
         $version = Version::id();
-        $this->assertTrue(strpos($version, self::VERSION) !== false, 'version should match');
+        $this->assertStringContainsString(self::VERSION, $version, 'version should match');
 
         $cachedVersion = Version::id();
-        $this->assertTrue(strpos($cachedVersion, self::VERSION) !== false, 'version should match');
+        $this->assertStringContainsString(self::VERSION, $cachedVersion, 'version should match');
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Using `use PHPUnit\Framework\TestCase` namespace to replace `extends \PHPUnit\Framework\TestCase`.
- Using the `assertCount` to assert expected count is same as result count.
- Using the `assertIsArray` and `assertIsFloat` to assert expected type is `array` or `float`.
- Using the `assertInstanceOf` to assert expected is same as specific class instance name.
- Using the `assertFileExists` or `assertFileNotExists` to assert expected file is existed or not existed.
- Using the short array syntax for all PHP codes on `tests` folder.
- Using the `assertTrue` or `assertFalse` to assert expected is same as `true` or `false`.
- Using the `assertStringContainsString` or `assertStringNotContainsString` to assert expected string contains or doesn't contain specific strings.
- Using the `assertDirectoryExists` to assert expected directory is existed.
- Using short array syntax for all PHP codes on `tests` folder.