### PR TITLE
Add --events flag to mysqldump

### DIFF
--- a/src/Backup/Source/Mysqldump.php
+++ b/src/Backup/Source/Mysqldump.php
@@ -201,6 +201,13 @@ class Mysqldump extends SimulatorExecutable implements Simulator, Restorable
     private $routines;
 
     /**
+     * Dump scheduled events
+     *
+     * @var bool
+     */
+    private $events;
+
+    /**
      * Skip triggers
      * --skip-triggers
      *
@@ -238,6 +245,7 @@ class Mysqldump extends SimulatorExecutable implements Simulator, Restorable
         $this->noData             = Util\Str::toBoolean(Util\Arr::getValue($conf, 'noData', ''), false);
         $this->filePerTable       = Util\Str::toBoolean(Util\Arr::getValue($conf, 'filePerTable', ''), false);
         $this->routines           = Util\Str::toBoolean(Util\Arr::getValue($conf, 'routines', ''), false);
+        $this->events             = Util\Str::toBoolean(Util\Arr::getValue($conf, 'events', ''), false);
         $this->skipTriggers       = Util\Str::toBoolean(Util\Arr::getValue($conf, 'skipTriggers', ''), false);
 
         // this doesn't fail, but it doesn't work, so throw an exception so the user understands
@@ -369,6 +377,7 @@ class Mysqldump extends SimulatorExecutable implements Simulator, Restorable
                    ->produceFilePerTable($this->filePerTable)
                    ->dumpNoData($this->noData)
                    ->dumpRoutines($this->routines)
+                   ->dumpEvents($this->events)
                    ->skipTriggers($this->skipTriggers)
                    ->dumpStructureOnly($this->structureOnly)
                    ->dumpTo($this->getDumpTarget($target));

--- a/src/Cli/Executable/Mysqldump.php
+++ b/src/Cli/Executable/Mysqldump.php
@@ -181,6 +181,14 @@ class Mysqldump extends Abstraction implements Executable
     private $routines = false;
 
     /**
+     * Dump scheduled events.
+     * --events
+     *
+     * @var bool
+     */
+    private $events = false;
+
+    /**
      * Skip triggers
      * --skip-triggers
      *
@@ -444,6 +452,18 @@ class Mysqldump extends Abstraction implements Executable
     }
 
     /**
+     * Dump scheduled events
+     *
+     * @param  bool $bool
+     * @return \phpbu\App\Cli\Executable\Mysqldump
+     */
+    public function dumpEvents(bool $bool) : Mysqldump
+    {
+        $this->events = $bool;
+        return $this;
+    }
+
+    /**
      * Skip triggers
      *
      * @param  bool $bool
@@ -505,6 +525,7 @@ class Mysqldump extends Abstraction implements Executable
         $cmd->addOptionIfNotEmpty('--set-gtid-purged', $this->gtidPurged);
         $cmd->addOptionIfNotEmpty('--ssl-ca', $this->sslCa);
         $cmd->addOptionIfNotEmpty('--routines', $this->routines, false);
+        $cmd->addOptionIfNotEmpty('--events', $this->events, false);
         $cmd->addOptionIfNotEmpty('--skip-triggers', $this->skipTriggers, false);
 
         $this->configureSourceData($cmd);

--- a/tests/phpbu/Backup/Source/MysqldumpTest.php
+++ b/tests/phpbu/Backup/Source/MysqldumpTest.php
@@ -210,6 +210,20 @@ class MysqldumpTest extends TestCase
     }
 
     /**
+     * Tests Mysqldump::
+     */
+    public function testEvents()
+    {
+        $target    = $this->createTargetMock();
+        $mysqldump = new Mysqldump();
+        $mysqldump->setup(['pathToMysqldump' => PHPBU_TEST_BIN, 'events' => 'true']);
+
+        $executable = $mysqldump->getExecutable($target);
+
+        $this->assertEquals(PHPBU_TEST_BIN . '/mysqldump --events --all-databases', $executable->getCommand());
+    }
+
+    /**
      * Tests Mysqldump::backup
      */
     public function testBackupOk()

--- a/tests/phpbu/Cli/Executable/MysqldumpTest.php
+++ b/tests/phpbu/Cli/Executable/MysqldumpTest.php
@@ -227,6 +227,18 @@ class MysqldumpTest extends TestCase
     }
 
     /**
+     * Tests Mysqldump::dumpEvents
+     */
+    public function testEvents()
+    {
+        $path      = realpath(__DIR__ . '/../../../_files/bin');
+        $mysqldump = new Mysqldump($path);
+        $mysqldump->dumpEvents(true);
+
+        $this->assertEquals($path . '/mysqldump --events --all-databases', $mysqldump->getCommand());
+    }
+
+    /**
      * Tests Mysqldump::getCommand
      */
     public function testGTIDValid()


### PR DESCRIPTION
This PR adds an option to include the --events flag to the mysqldump command. 