### PR TITLE
Pgdump sslmode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - if [ $TRAVIS_PHP_VERSION = "7.4" ]; then wget -O phpstan.phar https://github.com/phpstan/phpstan/releases/download/0.12.18/phpstan.phar ; fi
 
 script:
-  - php phpunit.phar --configuration ./build/travis-ci.phpunit.xml
+  - XDEBUG_MODE=coverage php phpunit.phar --configuration ./build/travis-ci.phpunit.xml
   - if [ $TRAVIS_PHP_VERSION = "7.4" ]; then php phpstan.phar analyse --no-progress -c phpstan.neon; fi
 
 notifications:

--- a/src/Backup/Source/Pgdump.php
+++ b/src/Backup/Source/Pgdump.php
@@ -170,6 +170,14 @@ class Pgdump extends SimulatorExecutable implements Simulator
     private $noPrivileges;
 
     /**
+     * Set SSL mode
+     * PGSSLMODE=allow pg_dump ...
+     *
+     * @var string
+     */
+    private $sslMode;
+
+    /**
      * Setup
      *
      * @see    \phpbu\App\Backup\Source
@@ -196,6 +204,7 @@ class Pgdump extends SimulatorExecutable implements Simulator
         $this->port     = Util\Arr::getValue($conf, 'port', 0);
         $this->user     = Util\Arr::getValue($conf, 'user', '');
         $this->password = Util\Arr::getValue($conf, 'password', '');
+        $this->sslMode  = Util\Arr::getValue($conf, 'sslMode', '');
     }
 
     /**
@@ -264,6 +273,7 @@ class Pgdump extends SimulatorExecutable implements Simulator
         $executable->credentials($this->user, $this->password)
                    ->useHost($this->host)
                    ->usePort($this->port)
+                   ->sslMode($this->sslMode)
                    ->dumpDatabase($this->database)
                    ->dumpSchemas($this->schemas)
                    ->excludeSchemas($this->excludeSchemas)

--- a/src/Cli/Executable/Pgdump.php
+++ b/src/Cli/Executable/Pgdump.php
@@ -38,6 +38,14 @@ class Pgdump extends Abstraction implements Executable
     private $port;
 
     /**
+     * Set SSL mode
+     * PGSSLMODE=allow pg_dump ...
+     *
+     * @var string
+     */
+    private $sslMode;
+
+    /**
      * User to connect with
      * --user=<username>
      *
@@ -190,6 +198,20 @@ class Pgdump extends Abstraction implements Executable
     ];
 
     /**
+     * List of available sslmode
+     *
+     * @var array
+     */
+    private $availableSslMode = [
+        'disable' => true,
+        'allow' => true,
+        'prefer' => true,
+        'require' => true,
+        'verify-ca' => true,
+        'verify-full' => true,
+    ];
+
+    /**
      * Constructor.
      *
      * @param string $path
@@ -235,6 +257,21 @@ class Pgdump extends Abstraction implements Executable
     public function usePort(int $port) : Pgdump
     {
         $this->port = $port;
+        return $this;
+    }
+
+    /**
+     * Set the sslmode
+     *
+     * @param string $sslMode
+     * @return Pgdump
+     */
+    public function sslMode(string $sslMode): Pgdump
+    {
+        if ($sslMode && !isset($this->availableSslMode[$sslMode])) {
+            throw new Exception('invalid sslMode');
+        }
+        $this->sslMode = $sslMode;
         return $this;
     }
 
@@ -454,7 +491,8 @@ class Pgdump extends Abstraction implements Executable
     {
         $process  = new CommandLine();
         $password = $this->password ? 'PGPASSWORD=' . escapeshellarg($this->password) . ' ' : '';
-        $cmd      = new Cmd($password . $this->binary);
+        $sslMode  = $this->sslMode ? 'PGSSLMODE=' . escapeshellarg($this->sslMode) . ' ' : '';
+        $cmd      = new Cmd($sslMode . $password . $this->binary);
         $process->addCommand($cmd);
 
         // always disable password prompt

--- a/tests/phpbu/Backup/Source/InfluxdumpTest.php
+++ b/tests/phpbu/Backup/Source/InfluxdumpTest.php
@@ -115,7 +115,7 @@ class InfluxdumpTest extends TestCase
         try {
             $influxd->backup($target, $appResult);
         } catch (Exception $e) {
-            $this->assertFileDoesNotExist($file);
+            $this->assertFileNotExists($file);
             throw $e;
         }
     }

--- a/tests/phpbu/Backup/Source/LdapdumpTest.php
+++ b/tests/phpbu/Backup/Source/LdapdumpTest.php
@@ -200,7 +200,7 @@ class LdapdumpTest extends TestCase
         try {
             $ldap->backup($target, $appResult);
         } catch (Exception $e) {
-            $this->assertFileDoesNotExist($file);
+            $this->assertFileNotExists($file);
             throw $e;
         }
     }

--- a/tests/phpbu/Backup/Source/MysqldumpTest.php
+++ b/tests/phpbu/Backup/Source/MysqldumpTest.php
@@ -338,7 +338,7 @@ class MysqldumpTest extends TestCase
         try {
             $mysqldump->backup($target, $appResult);
         } catch (Exception $e) {
-            $this->assertFileDoesNotExist($file);
+            $this->assertFileNotExists($file);
             throw $e;
         }
     }

--- a/tests/phpbu/Backup/Source/PgdumpTest.php
+++ b/tests/phpbu/Backup/Source/PgdumpTest.php
@@ -41,6 +41,23 @@ class PgdumpTest extends TestCase
     /**
      * Tests Pgdump::getExecutable
      */
+    public function testSslMode()
+    {
+        $target = $this->createTargetMock('foo.sql');
+        $pgDump = new Pgdump();
+        $pgDump->setup(['pathToPgdump' => PHPBU_TEST_BIN, 'sslMode' => 'require']);
+
+        $executable = $pgDump->getExecutable($target);
+
+        $this->assertEquals(
+            'PGSSLMODE=\'require\' ' . PHPBU_TEST_BIN . '/pg_dump -w --file=\'foo.sql\' --format=\'p\'',
+            $executable->getCommand()
+        );
+    }
+
+    /**
+     * Tests Pgdump::getExecutable
+     */
     public function testDatabase()
     {
         $target = $this->createTargetMock('foo.sql');

--- a/tests/phpbu/Util/CliTest.php
+++ b/tests/phpbu/Util/CliTest.php
@@ -181,10 +181,10 @@ class CliTest extends TestCase
 
         Cli::removeDir($dirToDelete);
 
-        $this->assertFileDoesNotExist($file);
-        $this->assertFileDoesNotExist($fileInSub);
-        $this->assertFileDoesNotExist($subDir);
-        $this->assertFileDoesNotExist($dirToDelete);
+        $this->assertFileNotExists($file);
+        $this->assertFileNotExists($fileInSub);
+        $this->assertFileNotExists($subDir);
+        $this->assertFileNotExists($dirToDelete);
     }
 
     /**


### PR DESCRIPTION
Add sslmode option to pgdump to configure the behavior of pg_dump when connecting to a ssl enabled server.

Note : also a fix on 3 tests using removed assert method in phpunit