### PR TITLE
Features/pgdump njobs

### DIFF
--- a/doc/config/source/pgdump.json
+++ b/doc/config/source/pgdump.json
@@ -3,6 +3,7 @@
   "options": {
     "host": "localhost",
     "port": "1234",
+    "jobs": "4",
     "user": "myUserName",
     "password": "topSecret",
     "database": "myDatabaseName",

--- a/doc/config/source/pgdump.xml
+++ b/doc/config/source/pgdump.xml
@@ -7,6 +7,9 @@
   <option name="port" value="1234" />
 
   <!-- optional, default none -->
+  <option name="jobs" value="4" />
+
+  <!-- optional, default none -->
   <option name="user" value="myUserName" />
 
   <!-- optional, default none -->

--- a/src/Backup/Source/Pgdump.php
+++ b/src/Backup/Source/Pgdump.php
@@ -51,6 +51,15 @@ class Pgdump extends SimulatorExecutable implements Simulator
     private $port;
 
     /**
+     * Run the dump in parallel by dumping njobs tables simultaneously.
+     * Reduces the time of the dump but it also increases the load on the database server.
+     * --jobs=<NJobs>
+     *
+     * @var int
+     */
+    private $jobs
+
+    /**
      * User to connect with
      * --user=<username>
      *
@@ -236,6 +245,7 @@ class Pgdump extends SimulatorExecutable implements Simulator
         $this->noOwner      = Util\Str::toBoolean(Util\Arr::getValue($conf, 'noOwner', ''), false);
         $this->encoding     = Util\Arr::getValue($conf, 'encoding', '');
         $this->format       = Util\Arr::getValue($conf, 'format', self::DEFAULT_FORMAT);
+        $this->jobs         = Util\Arr::getValue($conf, 'jobs', 0);
     }
 
 
@@ -285,6 +295,7 @@ class Pgdump extends SimulatorExecutable implements Simulator
                    ->dumpNoPrivileges($this->noPrivileges)
                    ->dumpNoOwner($this->noOwner)
                    ->dumpFormat($this->format)
+                   ->dumpJobs($this->jobs)
                    ->dumpTo($target->getPathnamePlain());
         return $executable;
     }

--- a/src/Backup/Source/Pgdump.php
+++ b/src/Backup/Source/Pgdump.php
@@ -57,7 +57,7 @@ class Pgdump extends SimulatorExecutable implements Simulator
      *
      * @var int
      */
-    private $jobs
+    private $jobs;
 
     /**
      * User to connect with

--- a/src/Cli/Executable/Pgdump.php
+++ b/src/Cli/Executable/Pgdump.php
@@ -36,6 +36,13 @@ class Pgdump extends Abstraction implements Executable
      * @var int
      */
     private $port;
+    
+    /**
+    * Run the dump in parallel by dumping njobs tables simultaneously.
+    * --jobs=njobs
+    * @var int
+    */
+    private $jobs;
 
     /**
      * Set SSL mode
@@ -180,7 +187,7 @@ class Pgdump extends Abstraction implements Executable
      * @var string
      */
     private $file;
-
+    
     /**
      * List of available output formats
      *
@@ -257,6 +264,18 @@ class Pgdump extends Abstraction implements Executable
     public function usePort(int $port) : Pgdump
     {
         $this->port = $port;
+        return $this;
+    }
+
+    /**
+     * Define njobs tables simultaneously..
+     *
+     * @param  int $jobs
+     * @return \phpbu\App\Cli\Executable\Pgdump
+     */
+    public function useJobs(int $jobs) : Pgdump
+    {
+        $this->jobs = $jobs;
         return $this;
     }
 
@@ -501,6 +520,7 @@ class Pgdump extends Abstraction implements Executable
         $cmd->addOptionIfNotEmpty('--username', $this->user);
         $cmd->addOptionIfNotEmpty('--host', $this->host);
         $cmd->addOptionIfNotEmpty('--port', $this->port);
+        $cmd->addOptionIfNotEmpty('--jobs', $this->jobs);
         $cmd->addOptionIfNotEmpty('--dbname', $this->databaseToDump);
         $cmd->addOptionIfNotEmpty('--schema-only', $this->schemaOnly, false);
         $cmd->addOptionIfNotEmpty('--data-only', $this->dataOnly, false);
@@ -509,6 +529,7 @@ class Pgdump extends Abstraction implements Executable
         $cmd->addOptionIfNotEmpty('--encoding', $this->encoding);
         $cmd->addOptionIfNotEmpty('--no-tablespaces', $this->noTablespaces, false);
         $cmd->addOptionIfNotEmpty('--no-acl', $this->noPrivileges, false);
+        
 
         $this->handleSchemas($cmd);
         $this->handleTables($cmd);

--- a/src/Cli/Executable/Pgdump.php
+++ b/src/Cli/Executable/Pgdump.php
@@ -273,7 +273,7 @@ class Pgdump extends Abstraction implements Executable
      * @param  int $jobs
      * @return \phpbu\App\Cli\Executable\Pgdump
      */
-    public function useJobs(int $jobs) : Pgdump
+    public function dumpJobs(int $jobs) : Pgdump
     {
         $this->jobs = $jobs;
         return $this;

--- a/src/Cli/Executable/Pgdump.php
+++ b/src/Cli/Executable/Pgdump.php
@@ -273,8 +273,11 @@ class Pgdump extends Abstraction implements Executable
      * @param  int $jobs
      * @return \phpbu\App\Cli\Executable\Pgdump
      */
-    public function dumpJobs(int $jobs) : Pgdump
+    public function dumpJobs(int $jobs): Pgdump
     {
+        if ($jobs < 0) {
+            throw new Exception('invalid jobs value');
+        }
         $this->jobs = $jobs;
         return $this;
     }

--- a/tests/phpbu/Cli/Executable/PgdumpTest.php
+++ b/tests/phpbu/Cli/Executable/PgdumpTest.php
@@ -261,7 +261,7 @@ class PgdumpTest extends TestCase
         $pgdump->dumpDatabase('phpbu')->dumpJobs(4)->dumpTo($file);
 
         $this->assertEquals(
-            PHPBU_TEST_BIN . '/pg_dump -w --dbname=\'phpbu\' --file=\'/tmp/foo\' --jobs=4',
+            PHPBU_TEST_BIN . '/pg_dump -w --jobs=4 --dbname=\'phpbu\' --file=\'/tmp/foo\'',
             $pgdump->getCommand()
         );
     }

--- a/tests/phpbu/Cli/Executable/PgdumpTest.php
+++ b/tests/phpbu/Cli/Executable/PgdumpTest.php
@@ -261,7 +261,7 @@ class PgdumpTest extends TestCase
         $pgdump->dumpDatabase('phpbu')->dumpJobs(4)->dumpTo($file);
 
         $this->assertEquals(
-            PHPBU_TEST_BIN . '/pg_dump -w --jobs=4 --dbname=\'phpbu\' --file=\'/tmp/foo\'',
+            PHPBU_TEST_BIN . '/pg_dump -w --jobs=\'4\' --dbname=\'phpbu\' --file=\'/tmp/foo\'',
             $pgdump->getCommand()
         );
     }

--- a/tests/phpbu/Cli/Executable/PgdumpTest.php
+++ b/tests/phpbu/Cli/Executable/PgdumpTest.php
@@ -254,6 +254,33 @@ class PgdumpTest extends TestCase
     /**
      * Tests Pgdump::getCommand
      */
+    public function testJobs()
+    {
+        $file   = '/tmp/foo';
+        $pgdump = new Pgdump(PHPBU_TEST_BIN);
+        $pgdump->dumpDatabase('phpbu')->dumpJobs(4)->dumpTo($file);
+
+        $this->assertEquals(
+            PHPBU_TEST_BIN . '/pg_dump -w --dbname=\'phpbu\' --file=\'/tmp/foo\' --jobs=4',
+            $pgdump->getCommand()
+        );
+    }
+
+    /**
+     * Tests Pgdump::getCommand
+     */
+    public function testInvalidJobs()
+    {
+        $this->expectException('phpbu\App\Exception');
+        $file   = '/tmp/foo';
+        $pgdump = new Pgdump(PHPBU_TEST_BIN);
+        $pgdump->dumpDatabase('phpbu')->dumpJobs(-1)->dumpTo($file);
+    }
+
+
+    /**
+     * Tests Pgdump::getCommand
+     */
     public function testFormat()
     {
         $file   = '/tmp/foo';


### PR DESCRIPTION
Added the function of NJobs to PGDump
"Run the dump in parallel by dumping njobs tables simultaneously. This option reduces the time of the dump but it also increases the load on the database server. You can only use this option with the directory output format because this is the only output format where multiple processes can write their data at the same time." - https://www.postgresql.org/docs/12/app-pgdump.html