### PR TITLE
Add support for S3 compatible providers

### DIFF
--- a/src/Backup/Sync/AmazonS3.php
+++ b/src/Backup/Sync/AmazonS3.php
@@ -97,7 +97,7 @@ abstract class AmazonS3 implements Simulator
     protected $endpoint;
     
     /**
-     * Set path style endpoint 
+     * Set path style endpoint
      *
      * @var boolean
      */
@@ -197,7 +197,7 @@ abstract class AmazonS3 implements Simulator
      * @throws \phpbu\App\Exception
      */
     protected function useMultiPartUpload(Target $target)
-    {    
+    {
         return (
             // files uploaded with multi part upload have to be at least 5MB
             $target->getSize() > $this->minMultiPartUploadSize

--- a/src/Backup/Sync/AmazonS3.php
+++ b/src/Backup/Sync/AmazonS3.php
@@ -90,6 +90,28 @@ abstract class AmazonS3 implements Simulator
     protected $multiPartUpload;
 
     /**
+     * Set a custom S3 endpoint
+     *
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Use specific S3 signature version
+     *
+     * @var string
+     */
+    protected $signature_version;
+
+    /**
+     * Set path style endpoint 
+     *
+     * @var boolean
+     */
+    protected $use_path_style_endpoint;
+
+
+    /**
      * Min multi part upload size
      *
      * @var int
@@ -130,6 +152,9 @@ abstract class AmazonS3 implements Simulator
         $this->pathRaw         = $cleanedPath;
         $this->acl             = Util\Arr::getValue($config, 'acl', 'private');
         $this->multiPartUpload = Util\Str::toBoolean(Util\Arr::getValue($config, 'useMultiPartUpload'), false);
+        $this->use_path_style_endpoint = Util\Str::toBoolean(Util\Arr::getValue($config, 'use_path_style_endpoint'), false);
+        if (Util\Arr::isSetAndNotEmptyString($config, 'endpoint')) $this->endpoint = $config['endpoint'];
+        if (Util\Arr::isSetAndNotEmptyString($config, 'signature_version')) $this->signature_version = $config['signature_version'];
     }
 
     /**
@@ -158,10 +183,10 @@ abstract class AmazonS3 implements Simulator
     {
         $result->debug(
             'sync backup to Amazon S3' . PHP_EOL
-            . '  region:   ' . $this->region . PHP_EOL
-            . '  key:      ' . $this->key . PHP_EOL
-            . '  secret:    ********' . PHP_EOL
-            . '  location: ' . $this->bucket . PHP_EOL
+                . '  region:   ' . $this->region . PHP_EOL
+                . '  key:      ' . $this->key . PHP_EOL
+                . '  secret:    ********' . PHP_EOL
+                . '  location: ' . $this->bucket . PHP_EOL
         );
     }
 
@@ -178,6 +203,6 @@ abstract class AmazonS3 implements Simulator
         // files uploaded with multi part upload has to be at least 5MB
         return (
             ($target->getSize() > $this->maxStreamUploadSize || $this->multiPartUpload)
-        ) && $target->getSize() > $this->minMultiPartUploadSize;
+            ) && $target->getSize() > $this->minMultiPartUploadSize;
     }
 }

--- a/src/Backup/Sync/AmazonS3v3.php
+++ b/src/Backup/Sync/AmazonS3v3.php
@@ -80,18 +80,23 @@ class AmazonS3v3 extends AmazonS3
      */
     protected function createClient() : S3Client
     {
-        $client_config = [
-            'region'      => $this->region,
-            'version'     => '2006-03-01',
-            'credentials' => [
+        $config = [
+            'region'                  => $this->region,
+            'version'                 => '2006-03-01',
+            'use_path_style_endpoint' => $this->usePathStyle,
+            'credentials'             => [
                 'key'    => $this->key,
                 'secret' => $this->secret,
-            ],
-            'use_path_style_endpoint'     => $this->use_path_style_endpoint,
+            ]
         ];
-        if ($this->endpoint) $client_config['endpoint'] = $this->endpoint;
-        if ($this->signature_version) $client_config['signature_version'] = $this->signature_version;
-        return new S3Client($client_config);
+        if ($this->endpoint) {
+            $config['endpoint'] = $this->endpoint;
+        }
+        if ($this->signatureVersion) {
+            $config['signature_version'] = $this->signatureVersion;
+        }
+        
+        return new S3Client($config);
     }
 
     /**

--- a/src/Backup/Sync/AmazonS3v3.php
+++ b/src/Backup/Sync/AmazonS3v3.php
@@ -80,14 +80,18 @@ class AmazonS3v3 extends AmazonS3
      */
     protected function createClient() : S3Client
     {
-        return new S3Client([
+        $client_config = [
             'region'      => $this->region,
             'version'     => '2006-03-01',
             'credentials' => [
                 'key'    => $this->key,
                 'secret' => $this->secret,
-            ]
-        ]);
+            ],
+            'use_path_style_endpoint'     => $this->use_path_style_endpoint,
+        ];
+        if ($this->endpoint) $client_config['endpoint'] = $this->endpoint;
+        if ($this->signature_version) $client_config['signature_version'] = $this->signature_version;
+        return new S3Client($client_config);
     }
 
     /**


### PR DESCRIPTION
This adds support for S3 compatible APIs like BackBlaze, Oracle, Yandex Cloud and many more by adding the following configuration options:

* endpoint
    * Service endpoint of the API provider
* signature version
    * Many API providers only support version v4
* path style endpoints
    * Some API providers do not support bucket endpoint URls