### PR TITLE
Fix debug-flag in configuration files (#323)

### DIFF
--- a/phpbu.xsd
+++ b/phpbu.xsd
@@ -122,6 +122,7 @@
     <xs:attribute name="bootstrap" type="xs:anyURI"/>
     <xs:attribute name="verbose" type="xs:boolean" default="false"/>
     <xs:attribute name="colors" type="xs:boolean" default="false"/>
+    <xs:attribute name="debug" type="xs:boolean" default="false"/>
   </xs:attributeGroup>
 
   <xs:group name="configGroup">

--- a/src/Configuration/Loader/Json.php
+++ b/src/Configuration/Loader/Json.php
@@ -121,6 +121,9 @@ class Json extends File implements Loader
         if (isset($this->json['colors'])) {
             $configuration->setColors($this->json['colors']);
         }
+        if (isset($this->json['debug'])) {
+            $configuration->setDebug($this->json['debug']);
+        }
     }
 
     /**

--- a/src/Configuration/Loader/Xml.php
+++ b/src/Configuration/Loader/Xml.php
@@ -139,6 +139,9 @@ class Xml extends File implements Loader
         if ($root->hasAttribute('colors')) {
             $configuration->setColors(Str::toBoolean($root->getAttribute('colors'), false));
         }
+        if ($root->hasAttribute('debug')) {
+            $configuration->setDebug(Str::toBoolean($root->getAttribute('debug'), false));
+        }
     }
 
     /**

--- a/tests/_files/conf/json/config-with-debug.json
+++ b/tests/_files/conf/json/config-with-debug.json
@@ -1,0 +1,19 @@
+{
+  "debug": true,
+  "backups": [
+    {
+      "name": "tarball",
+      "source": {
+        "type": "tar",
+        "options": {
+          "path": "src"
+        }
+      },
+      "target": {
+        "dirname": "backup/src",
+        "filename": "tarball-%Y%m%d-%H%i.tar",
+        "compress": "bzip2"
+      }
+    }
+  ]
+}

--- a/tests/_files/conf/xml/config-with-debug.xml
+++ b/tests/_files/conf/xml/config-with-debug.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpbu bootstrap="backup/bootstrap.php" debug="true">
+    <backups>
+        <backup name="tarball">
+            <source type="tar">
+                <option name="path" value="src"/>
+            </source>
+            <target dirname="backup/src" filename="tarball-%Y%m%d-%H%i.tar" compress="bzip2"/>
+        </backup>
+    </backups>
+</phpbu>

--- a/tests/phpbu/Configuration/Loader/JsonTest.php
+++ b/tests/phpbu/Configuration/Loader/JsonTest.php
@@ -139,6 +139,13 @@ class JsonTest extends TestCase
         $config = $loader->getConfiguration(self::$factory);
     }
 
+    public function testWithDebug(): void
+    {
+        $loader = new Json(PHPBU_TEST_FILES . '/conf/json/config-with-debug.json', $this->getBootstrapperMock(true));
+        $config = $loader->getConfiguration(self::$factory);
+        $this->assertTrue($config->getDebug());
+    }
+
     /**
      * Tests Json::getConfiguration
      */
@@ -152,6 +159,7 @@ class JsonTest extends TestCase
         $this->assertEquals($dir . '/backup/bootstrap.php', $config->getBootstrap());
         $this->assertTrue($config->getColors());
         $this->assertFalse($config->getVerbose());
+        $this->assertFalse($config->getDebug());
     }
 
     /**

--- a/tests/phpbu/Configuration/Loader/XmlTest.php
+++ b/tests/phpbu/Configuration/Loader/XmlTest.php
@@ -146,6 +146,15 @@ class XmlTest extends TestCase
         $this->assertEquals('demo', $source->options['password']);
     }
 
+    public function testWithDebug(): void
+    {
+        $loader = new Xml(PHPBU_TEST_FILES . '/conf/xml/config-with-debug.xml', $this->getBootstrapperMock(true));
+        $config = $loader->getConfiguration(self::$factory);
+
+        $this->assertFalse($loader->hasValidationErrors());
+        $this->assertTrue($config->getDebug());
+    }
+
     /**
      * Tests Xml::getConfiguration
      */
@@ -161,6 +170,7 @@ class XmlTest extends TestCase
         $this->assertEquals($dir . '/backup/bootstrap.php', $config->getBootstrap());
         $this->assertTrue($config->getColors());
         $this->assertFalse($config->getVerbose());
+        $this->assertFalse($config->getDebug());
     }
 
     /**


### PR DESCRIPTION
According to the documentation, both the XML and JSON configuration format should support setting a `"debug"` flag. However, the XSD schema does not allow a `debug` attribute on the root `<phpbu>` node. Similarly, the JSON configuration loader ignores a top-level `"debug"` key, even though one is present in the example configuration in `\phpbu\App\Configuration\Loader\Json`.

This commit amends the XSD schma with an optional debug attribute on the phpbu-Type. Additionally, support for loading this value is added to the XML and JSON loader.