### PR TITLE
Fix missing error message with tar (fixes #314)

### DIFF
--- a/src/Backup/Source/Tar.php
+++ b/src/Backup/Source/Tar.php
@@ -224,9 +224,6 @@ class Tar extends SimulatorExecutable implements Simulator, Restorable
             throw new Exception('path option is mandatory');
         }
         $this->path = Util\Path::toAbsolutePath($path, Configuration::getWorkingDirectory());
-        if (!file_exists($this->path)) {
-            throw new Exception('could not find directory to compress');
-        }
     }
 
     /**
@@ -329,10 +326,14 @@ class Tar extends SimulatorExecutable implements Simulator, Restorable
      *
      * @throws \phpbu\App\Exception
      */
-    private function validatePath()
+    private function validatePath(): void
     {
+        if (!file_exists($this->path)) {
+            throw new Exception(sprintf('Could not find directory to compress at "%s".', $this->path));
+        }
+
         if (!is_dir($this->path)) {
-            throw new Exception('path to compress has to be a directory');
+            throw new Exception(sprintf('Cannot compress at path "%s": not a directory.', $this->path));
         }
     }
 

--- a/tests/phpbu/Backup/Source/TarTest.php
+++ b/tests/phpbu/Backup/Source/TarTest.php
@@ -40,13 +40,12 @@ class TarTest extends TestCase
     /**
      * Tests Tar::setUp
      */
-    public function testSetupPathDoesNotExist()
+    public function testSetupPathDoesNotExistDoesNotThrowException(): void
     {
-        $this->expectException('phpbu\App\Exception');
+        $this->expectNotToPerformAssertions();
+
         $tar = new Tar();
         $tar->setup(['path' => getcwd() . '/foo']);
-
-        $this->assertFalse(true, 'exception should be thrown');
     }
 
     /**
@@ -519,12 +518,29 @@ class TarTest extends TestCase
     /**
      * Tests Tar::backup
      */
-    public function testBackupInvalidPath()
+    public function testBackupThrowsExceptionWhenPathPointsToFile(): void
     {
         $this->expectException('phpbu\App\Exception');
+        $this->expectExceptionMessage(sprintf('Cannot compress at path "%s": not a directory.', __FILE__));
+
         $runner = $this->getRunnerMock();
         $tar    = new Tar($runner);
         $tar->setup(['pathToTar' => PHPBU_TEST_BIN, 'path' => __FILE__]);
+
+        $target    = $this->createTargetMock('/tmp/backup.tar');
+        $appResult = $this->getAppResultMock();
+
+        $tar->backup($target, $appResult);
+    }
+
+    public function testBackupThrowsExceptionWhenNoDirectoryExistsAtPath(): void
+    {
+        $this->expectException('phpbu\App\Exception');
+        $this->expectExceptionMessage('Could not find directory to compress at "/some/directory/that/does/not/exist".');
+
+        $runner = $this->getRunnerMock();
+        $tar    = new Tar($runner);
+        $tar->setup(['pathToTar' => PHPBU_TEST_BIN, 'path' => '/some/directory/that/does/not/exist']);
 
         $target    = $this->createTargetMock('/tmp/backup.tar');
         $appResult = $this->getAppResultMock();


### PR DESCRIPTION
When backing up from a `tar` source, phpbu used to check if the specified path exists during the `::setup()` stage, not the actual `::backup()` stage. 

This might cause phpbu to die by an "uncaught" exception  (aka. no logging / email being sent).

This commit removes the existence check from the `::setup()`, which already doubled an existing check in the `::backup()` stage (through `\phpbu\App\Backup\Source\Tar::validatePath`).