### PR TITLE
Add all Symfony libs to the PHAR

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -135,7 +135,14 @@
       </fileset>
     </copy>
 
-    <!-- AMAZON AWS -->
+    <!-- SYMFONY -->
+    <copy todir="${basedir}/build/phar/lib/symfony/">
+      <fileset dir="${basedir}/vendor/symfony/">
+         <include name="**/*.php"/>
+      </fileset>
+    </copy>
+
+      <!-- AMAZON AWS -->
     <copy file="${basedir}/vendor/aws/aws-sdk-php/LICENSE" tofile="${basedir}/build/phar/lib/aws-sdk/LICENSE"/>
     <copy todir="${basedir}/build/phar/lib/aws-sdk">
       <fileset dir="${basedir}/vendor/aws/aws-sdk-php/src">
@@ -447,16 +454,6 @@
     <copy todir="${basedir}/build/phar/lib/phpmailer">
       <fileset dir="${basedir}/vendor/phpmailer/phpmailer/src">
         <include name="**/*.php"/>
-      </fileset>
-    </copy>
-
-    <!-- Symfony libs -->
-    <copy file="${basedir}/vendor/symfony/options-resolver/LICENSE"
-          tofile="${basedir}/build/phar/lib/symfony/options-resolver/LICENSE"/>
-    <copy todir="${basedir}/build/phar/lib/symfony/options-resolver">
-      <fileset dir="${basedir}/vendor/symfony/options-resolver">
-        <include name="**/*.php"/>
-        <exclude name="**/Test*"/>
       </fileset>
     </copy>
 

--- a/build/phar-autoload.php.in
+++ b/build/phar-autoload.php.in
@@ -48,7 +48,11 @@ if ($execute) {
     // dropbox collection helper
     require __PHPBU_PHAR_ROOT__ . '/lib/tightenco/Collect/Support/helpers.php';
     require __PHPBU_PHAR_ROOT__ . '/lib/tightenco/Collect/Support/alias.php';
-    
+    // load the symfony polyfills
+    require __PHPBU_PHAR_ROOT__ . '/lib/symfony/polyfill-ctype/bootstrap.php';
+    require __PHPBU_PHAR_ROOT__ . '/lib/symfony/polyfill-mbstring/bootstrap.php';
+    require __PHPBU_PHAR_ROOT__ . '/lib/symfony/polyfill-php80/bootstrap.php';
+
     phpbu\App\Cmd::main();
 }
 


### PR DESCRIPTION
This makes sure all Symfony dependencies are added to the PHAR file.
This also loads all the necessary polyfills.

Fix issue #322