### PR TITLE
LockTables fix

### DIFF
--- a/src/Cli/Executable/Mysqldump.php
+++ b/src/Cli/Executable/Mysqldump.php
@@ -516,7 +516,7 @@ class Mysqldump extends Abstraction implements Executable
         $cmd->addOptionIfNotEmpty('--host', $this->host);
         $cmd->addOptionIfNotEmpty('--port', $this->port);
         $cmd->addOptionIfNotEmpty('--protocol', $this->protocol);
-        $cmd->addOptionIfNotEmpty('--lock-tables', $this->lockTables, false);
+        $cmd->addOptionIfNotEmpty('--lock-tables', json_encode($this->lockTables));
         $cmd->addOptionIfNotEmpty('--single-transaction', $this->singleTransaction, false);
         $cmd->addOptionIfNotEmpty('-q', $this->quick, false);
         $cmd->addOptionIfNotEmpty('-C', $this->compress, false);


### PR DESCRIPTION
Hello,
I did try to to set the lockTables to false in the XML configuration file, unfortunately this does not add appropriate parameter to the mysqldump command.

 i think that phpbu configuration:
`<option name="lockTables" value="false" />`
should result in the following output:
`/usr/bin/mysqldump --user='foo' --password='******' --lock-tables=false`
instead of
`/usr/bin/mysqldump --user='foo' --password='******' `