### PR TITLE
Add support for FTPS sync targets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
   },
   "require-dev": {
     "sebastianfeldmann/git": "^3.2",
-    "sebastianfeldmann/ftp": "^0.9",
+    "sebastianfeldmann/ftp": "^0.9.2",
     "guzzlehttp/guzzle": "^5.3.4|^6.5.8|^7.5.0",
     "aws/aws-sdk-php": "^3.10",
     "kunalvarma05/dropbox-php-sdk": "^0.4",
@@ -68,7 +68,7 @@
     "phpmailer/phpmailer": "^6.0"
   },
   "suggest": {
-    "sebastianfeldmann/ftp": "Require ^0.9 to sync to an FTP server",
+    "sebastianfeldmann/ftp": "Require ^0.9.2 to sync to an FTP server",
     "guzzlehttp/guzzle": "Require ^5.3.3|^6.2.1 to write logs to Telegram",
     "aws/aws-sdk-php": "Require '^3.10' to sync to Amazon S3",
     "kunalvarma05/dropbox-php-sdk": "Require '^0.2' to sync to Dropbox",

--- a/doc/config/sync/ftp.json
+++ b/doc/config/sync/ftp.json
@@ -5,7 +5,8 @@
     "user": "user.name",
     "password": "mySecret",
     "path": "someDir/someSubDir",
-    "passive": "false"
+    "passive": "false",
+    "secure": "false"
   }
 }
 

--- a/doc/config/sync/ftp.xml
+++ b/doc/config/sync/ftp.xml
@@ -14,4 +14,7 @@
 
   <!-- optional, default=false -->
   <option name="passive" value="true" />
+
+  <!-- optional, default=false -->
+  <option name="secure" value="true" />
 </sync>

--- a/src/Backup/Sync/Ftp.php
+++ b/src/Backup/Sync/Ftp.php
@@ -38,6 +38,13 @@ class Ftp extends Xtp
     protected $passive;
 
     /**
+     * If set to `true` connection is made via FTPS (explicit SSL).
+     *
+     * @var bool
+     */
+    protected $secure;
+
+    /**
      * Setup the Ftp sync
      *
      * @param  array $config
@@ -56,6 +63,7 @@ class Ftp extends Xtp
         parent::setup($config);
 
         $this->passive = Util\Str::toBoolean(Util\Arr::getValue($config, 'passive', ''), false);
+        $this->secure = Util\Str::toBoolean(Util\Arr::getValue($config, 'secure', ''), false);
         $this->setUpCleanable($config);
     }
 
@@ -113,7 +121,7 @@ class Ftp extends Xtp
     {
         if (!$this->ftpClient) {
             $login           = $this->user . ($this->password ? ':' . $this->password : '');
-            $this->ftpClient = new Client('ftp://' . $login . '@' . $this->host, $this->passive);
+            $this->ftpClient = new Client('ftp://' . $login . '@' . $this->host, $this->passive, $this->secure);
         }
         return $this->ftpClient;
     }


### PR DESCRIPTION
One of our FTP hosters has recently moved to FTP via explicit SSL only, so I needed to add FTPS support to phpBU.

Thankfully, your FTP wrapper already supports this functionality (since v0.9.2, hence the updates to `composer.json`), so I just added another optional boolean FTP config flag, similar to the `passive` flag.

This should be fully backwards-compatible, as the FTP-lib already defaulted to `$secure = false`.