### PR TITLE
Fix Xtrabackup8 dump dir argument

### DIFF
--- a/src/Cli/Executable/Xtrabackup8.php
+++ b/src/Cli/Executable/Xtrabackup8.php
@@ -175,7 +175,7 @@ class Xtrabackup8 extends Abstraction implements Executable
             $cmdDump->addOption('--databases', implode(' ', $this->databases));
         }
 
-        $cmdDump->addArgument($this->dumpDir);
+        $cmdDump->addOption('--target-dir', $this->dumpDir);
 
         return $process;
     }


### PR DESCRIPTION
Percona XtraBackup 8 requires the target directory as `--target-dir` option, not just as an argument. 

See https://docs.percona.com/percona-xtrabackup/innovation-release/create-full-backup.html and #370 