### PR TITLE
Set parameters for gpg encryption

### DIFF
--- a/src/Backup/Crypter/Gpg.php
+++ b/src/Backup/Crypter/Gpg.php
@@ -55,7 +55,7 @@ class Gpg extends Abstraction implements Simulator, Restorable
 
         $this->pathToGpg     = Util\Arr::getValue($options, 'pathToOpenSSL', '');
         $this->keepUncrypted = Util\Str::toBoolean(Util\Arr::getValue($options, 'keepUncrypted', ''), false);
-        $this->user          = $this->toAbsolutePath(Util\Arr::getValue($options, 'user', ''));
+        $this->user          = Util\Arr::getValue($options, 'user', '');
     }
 
     /**

--- a/src/Cli/Executable/Gpg.php
+++ b/src/Cli/Executable/Gpg.php
@@ -139,10 +139,24 @@ class Gpg extends Abstraction implements Executable
         $cmd     = new Cmd($this->binary);
 
         $process->addCommand($cmd);
+        $this->setOptions($cmd);
 
         $this->addDeleteCommand($process);
 
         return $process;
+    }
+
+    /**
+     * Set the gpg command line options
+     *
+     * @param \SebastianFeldmann\Cli\Command\Executable $cmd
+     */
+    protected function setOptions(Cmd $cmd): void
+    {
+        $cmd->addOption('--' . ($this->action === 'e' ? 'encrypt' : 'decrypt'));
+        $cmd->addOption('-r', $this->user, ' ');
+        $cmd->addOption('-o', $this->targetFile, ' ');
+        $cmd->addArgument($this->sourceFile);
     }
 
     /**


### PR DESCRIPTION
It seems that gpg encryption does not work as per #369.
Seems that the gpg executable wasn't given any parameters at all.
So I added those. Also modified the user parameter, which needs an username (email) of the gpg key in your keychain that you intend to encrypt the backup with.

Be noted that the key should be trusted, otherwise the gpg prompts for input, letting the backup hang. Maybe all keys could be automatically trusted with some parameter, or phpbu should check that the key is trusted beforehand.

Also, gpg by default compresses the file. That could also be configured.