### PR TITLE
Don't limit size when using OpenSSL password crypt

### DIFF
--- a/src/Backup/Crypter/OpenSSL.php
+++ b/src/Backup/Crypter/OpenSSL.php
@@ -107,7 +107,7 @@ class OpenSSL extends Abstraction implements Simulator, Restorable
 
             $result->warn($name . ': The ' . $this->algorithm . ' algorithm is considered weak');
         }
-        if ($target->getSize() > 1610612736) {
+        if (!empty($this->certFile) && $target->getSize() > 1610612736) {
             throw new Exception('Backup to big to encrypt: OpenSSL SMIME can only encrypt files smaller 1.5GB.');
         }
         parent::crypt($target, $result);

--- a/src/Backup/Target/Compression/Factory.php
+++ b/src/Backup/Target/Compression/Factory.php
@@ -25,7 +25,8 @@ class Factory
         'gzip'  => 'Gzip',
         'bzip2' => 'Bzip2',
         'xz'    => 'Xz',
-        'zip'   => 'Zip'
+        'zip'   => 'Zip',
+        'zstd'   => 'Zstd'
     ];
 
     /**

--- a/src/Backup/Target/Compression/Zstd.php
+++ b/src/Backup/Target/Compression/Zstd.php
@@ -1,0 +1,44 @@
+<?php
+namespace phpbu\App\Backup\Target\Compression;
+
+/**
+ * Zstd
+ *
+ * @package    phpbu
+ * @subpackage Backup
+ * @author     Sebastian Feldmann <sebastian@phpbu.de>
+ * @copyright  Sebastian Feldmann <sebastian@phpbu.de>
+ * @license    https://opensource.org/licenses/MIT The MIT License (MIT)
+ * @link       http://phpbu.de/
+ * @since      Class available since Release 3.2.1
+ */
+class Zstd extends Abstraction
+{
+    /**
+     * Command name
+     *
+     * @var string
+     */
+    protected $cmd = 'zstd';
+
+    /**
+     * Suffix for compressed files
+     *
+     * @var string
+     */
+    protected $suffix = 'zst';
+
+    /**
+     * MIME type for compressed files
+     *
+     * @var string
+     */
+    protected $mimeType = 'application/zstd';
+
+    /**
+     * Can this compression compress piped output
+     *
+     * @var bool
+     */
+    protected $pipeable = true;
+}

--- a/src/Cli/Executable/Tar.php
+++ b/src/Cli/Executable/Tar.php
@@ -96,6 +96,7 @@ class Tar extends Abstraction implements Executable
         'bzip2',
         'gzip',
         'xz',
+        'zstd'
     ];
 
     /**

--- a/src/Cli/Executable/Tar.php
+++ b/src/Cli/Executable/Tar.php
@@ -93,9 +93,9 @@ class Tar extends Abstraction implements Executable
      * @var array
      */
     private static $availableCompressions = [
-        'bzip2' => 'j',
-        'gzip'  => 'z',
-        'xz'    => 'J'
+        'bzip2',
+        'gzip',
+        'xz',
     ];
 
     /**
@@ -142,7 +142,7 @@ class Tar extends Abstraction implements Executable
      */
     protected function getCompressionOption(string $compressor) : string
     {
-        return $this->isCompressionValid($compressor) ? self::$availableCompressions[$compressor] : '';
+        return $this->isCompressionValid($compressor) ? $compressor : '';
     }
 
     /**
@@ -323,7 +323,11 @@ class Tar extends Abstraction implements Executable
         $tar->addOptionIfNotEmpty('-h', $this->dereference, false);
         $tar->addOptionIfNotEmpty('--force-local', $this->local, false);
         $tar->addOptionIfNotEmpty('--use-compress-program', $this->compressProgram);
-        $tar->addOption('-' . (empty($this->compressProgram) ? $this->compression : '') . $create);
+        if ($this->compression && empty($this->compressProgram)) {
+            $tar->addOption('--' . $this->compression);
+        }
+        $tar->addOption('-' . $create);
+
 
         if ($this->isThrottled()) {
             $pv = new Cmd('pv');
@@ -452,7 +456,7 @@ class Tar extends Abstraction implements Executable
      */
     public static function isCompressionValid(string  $compression) : bool
     {
-        return isset(self::$availableCompressions[$compression]);
+        return in_array($compression, self::$availableCompressions);
     }
 
     /**

--- a/tests/phpbu/Backup/Source/TarTest.php
+++ b/tests/phpbu/Backup/Source/TarTest.php
@@ -361,7 +361,7 @@ class TarTest extends TestCase
         $exec = $tar->getExecutable($target);
 
         $this->assertEquals(
-            '"' . PHPBU_TEST_BIN . '/tar" -zcf \'/tmp/backup.tar.gz\' -C \''
+            '"' . PHPBU_TEST_BIN . '/tar" --gzip -cf \'/tmp/backup.tar.gz\' -C \''
             . dirname(__DIR__) . '\' \''
             . basename(__DIR__) . '\'',
             $exec->getCommand()

--- a/tests/phpbu/Cli/Executable/TarTest.php
+++ b/tests/phpbu/Cli/Executable/TarTest.php
@@ -179,7 +179,7 @@ class TarTest extends TestCase
         $tar->archiveDirectory($dir)->archiveTo('/tmp/foo.tar.gz')->useCompression('gzip');
 
         $this->assertEquals(
-            '"' . PHPBU_TEST_BIN . '/tar" -zcf \'/tmp/foo.tar.gz\' -C \'' . $tarC .  '\' \'' . $tarD . '\'',
+            '"' . PHPBU_TEST_BIN . '/tar" --gzip -cf \'/tmp/foo.tar.gz\' -C \'' . $tarC .  '\' \'' . $tarD . '\'',
             $tar->getCommand()
         );
     }
@@ -196,7 +196,7 @@ class TarTest extends TestCase
         $tar->archiveDirectory($dir)->archiveTo('/tmp/foo.tar.bzip2')->useCompression('bzip2');
 
         $this->assertEquals(
-            '"' . PHPBU_TEST_BIN . '/tar" -jcf \'/tmp/foo.tar.bzip2\' -C \'' . $tarC .  '\' \'' . $tarD . '\'',
+            '"' . PHPBU_TEST_BIN . '/tar" --bzip2 -cf \'/tmp/foo.tar.bzip2\' -C \'' . $tarC .  '\' \'' . $tarD . '\'',
             $tar->getCommand()
         );
     }
@@ -216,7 +216,7 @@ class TarTest extends TestCase
             ->throttle('1m');
 
         $this->assertEquals(
-            '"' . PHPBU_TEST_BIN . '/tar" -jc -C \'' . $tarC .  '\' \'' . $tarD . '\''
+            '"' . PHPBU_TEST_BIN . '/tar" --bzip2 -c -C \'' . $tarC .  '\' \'' . $tarD . '\''
             . ' | "pv" -qL \'1m\' > /tmp/foo.tar.bzip2',
             $tar->getCommand()
         );
@@ -238,7 +238,7 @@ class TarTest extends TestCase
             ->throttle('1m');
 
         $this->assertEquals(
-            '("' . PHPBU_TEST_BIN . '/tar" -jc -C \'' . $tarC .  '\' \'' . $tarD . '\''
+            '("' . PHPBU_TEST_BIN . '/tar" --bzip2 -c -C \'' . $tarC .  '\' \'' . $tarD . '\''
             . ' && "rm" -rf \'' . $dir . '\')'
             . ' | "pv" -qL \'1m\' > /tmp/foo.tar.bzip2',
             $tar->getCommand()


### PR DESCRIPTION
When using OpenSSL password encryption with `enc` option, instead of SMIME, size is not limited.

I have successfully encrypted files tens of gigabytes in size.