### PR TITLE
PHP 8.4 support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['8.0', '8.1', '8.2', '8.3']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
     - uses: actions/checkout@master
 

--- a/src/Backup/Cli.php
+++ b/src/Backup/Cli.php
@@ -48,7 +48,7 @@ abstract class Cli
      * @param \SebastianFeldmann\Cli\Command\Runner $runner
      * @param int|null                              $time
      */
-    public function __construct(Runner $runner = null, ?int $time = null)
+    public function __construct(?Runner $runner = null, ?int $time = null)
     {
         $this->runner = $runner ? : new Runner\Simple(new Symfony());
         $this->time   = $time   ? : time();

--- a/src/Backup/Compressor/Abstraction.php
+++ b/src/Backup/Compressor/Abstraction.php
@@ -42,7 +42,7 @@ abstract class Abstraction extends Cli implements Compressible
      * @param  \SebastianFeldmann\Cli\Command\Runner $runner
      * @throws \phpbu\App\Exception
      */
-    public function __construct($path, $pathToCommand = '', Runner $runner = null)
+    public function __construct($path, $pathToCommand = '', ?Runner $runner = null)
     {
         if (empty($path)) {
             throw new Exception('no path to compress set');


### PR DESCRIPTION
PHP 8.4.3

```
PHP Deprecated:  phpbu\App\Backup\Cli::__construct(): Implicitly marking parameter $runner as nullable is deprecated, the explicit nullable type must be used instead in /builds/vendor/phpbu/phpbu/src/Backup/Cli.php on line 51
```